### PR TITLE
[JH] passport 인증 전략 변경, refresh token 저장 로직 추가

### DIFF
--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -15,7 +15,12 @@ const enum message {
 export default () => {
   const connect = () => {
     mongoose
-      .connect(DB_HOST!, { useNewUrlParser: true, useUnifiedTopology: true, dbName: DB_NAME })
+      .connect(DB_HOST!, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        useCreateIndex: true,
+        dbName: DB_NAME,
+      })
       .then(() => console.log(message.CONNECT_SUCCEED))
       .catch((err) => console.error(message.CONNECT_ERROR, err));
   };

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,12 +1,19 @@
 import { Schema, model } from 'mongoose';
 
+export const loginType = {
+  driver: '드라이버' as const,
+  user: '일반 사용자' as const,
+};
+
+export type LoginType = typeof loginType[keyof typeof loginType];
+
 const userSchema = new Schema({
   id: Schema.Types.ObjectId,
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   name: { type: String, required: true },
   phone: { type: String, required: true },
-  type: { type: String, required: true },
+  type: { type: String, required: true, enum: [loginType.driver, loginType.user] },
   profile: Schema.Types.String,
   payment: {
     type: {

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -2,7 +2,7 @@ import { Schema, model } from 'mongoose';
 
 const userSchema = new Schema({
   id: Schema.Types.ObjectId,
-  email: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   name: { type: String, required: true },
   phone: { type: String, required: true },

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -6,6 +6,7 @@ const userSchema = new Schema({
   password: { type: String, required: true },
   name: { type: String, required: true },
   phone: { type: String, required: true },
+  type: { type: String, required: true },
   profile: Schema.Types.String,
   payment: {
     type: {

--- a/server/src/passport/auth.ts
+++ b/server/src/passport/auth.ts
@@ -24,7 +24,7 @@ const loginAuth: ExpressFunction = async (req, res, next) => {
       const refreshToken = jwt.sign(payload, JWT_SECRET_KEY!, { expiresIn: '14d' });
 
       const userData = await UserModel.findOne({ email: user.email });
-      await UserModel.update({ _id: userData?.get('_id') }, { refreshToken });
+      await UserModel.updateOne({ _id: userData?.get('_id') }, { refreshToken });
 
       res.status(200).json({ result: 'success', accessToken });
     })(req, res, next);

--- a/server/src/passport/local.ts
+++ b/server/src/passport/local.ts
@@ -7,11 +7,7 @@ import { Request } from 'express';
 
 import { isComparedPassword } from '@util/bcrypt';
 import { Message } from '@util/server-message';
-import UserModel from '@models/user';
-
-interface LoginType {
-  loginType: '일반 사용자' | '드라이버';
-}
+import UserModel, { LoginType } from '@models/user';
 
 const config: IStrategyOptionsWithRequest = {
   passReqToCallback: true,
@@ -26,7 +22,7 @@ const authenticate: VerifyFunctionWithRequest = async (
   done,
 ) => {
   try {
-    const { loginType }: LoginType = req.body;
+    const loginType = req.body.loginType as LoginType;
     const user = await UserModel.findOne({ email, type: loginType });
 
     if (!user) return done(null, false, { message: Message.InvalidEmail });

--- a/server/src/passport/local.ts
+++ b/server/src/passport/local.ts
@@ -1,21 +1,21 @@
 import { Strategy as LocalStrategy, VerifyFunction } from 'passport-local';
+
 import { isComparedPassword } from '@util/bcrypt';
 import { Message } from '@util/server-message';
+import UserModel from '@models/user';
 
 const config = { usernameField: 'email', passwordField: 'password' };
-const mock = {
-  email: 'gildong@test.com',
-  password: '$2b$10$UzWKr4Em04s.UVjHZf1fHe8rc39voVNMuUhVCW7KP.tc0vrbmNW.K',
-};
 
 const authenticate: VerifyFunction = async (email: string, password: string, done) => {
   try {
-    if (mock.email !== email) return done(null, false, { message: Message.InvalidEmail });
-    if (!isComparedPassword(password, mock.password)) {
+    const user = await UserModel.findOne({ email });
+
+    if (!user) return done(null, false, { message: Message.InvalidEmail });
+    if (!isComparedPassword(password, user?.get('password'))) {
       return done(null, false, { message: Message.InvalidPassword });
     }
 
-    return done(null, mock, { message: Message.SucceedLogin });
+    return done(null, user, { message: Message.SucceedLogin });
   } catch (error) {
     done(error);
   }

--- a/server/src/passport/local.ts
+++ b/server/src/passport/local.ts
@@ -1,14 +1,33 @@
-import { Strategy as LocalStrategy, VerifyFunction } from 'passport-local';
+import {
+  Strategy as LocalStrategy,
+  VerifyFunctionWithRequest,
+  IStrategyOptionsWithRequest,
+} from 'passport-local';
+import { Request } from 'express';
 
 import { isComparedPassword } from '@util/bcrypt';
 import { Message } from '@util/server-message';
 import UserModel from '@models/user';
 
-const config = { usernameField: 'email', passwordField: 'password' };
+interface LoginType {
+  loginType: '일반 사용자' | '드라이버';
+}
 
-const authenticate: VerifyFunction = async (email: string, password: string, done) => {
+const config: IStrategyOptionsWithRequest = {
+  passReqToCallback: true,
+  usernameField: 'email',
+  passwordField: 'password',
+};
+
+const authenticate: VerifyFunctionWithRequest = async (
+  req: Request,
+  email: string,
+  password: string,
+  done,
+) => {
   try {
-    const user = await UserModel.findOne({ email });
+    const { loginType }: LoginType = req.body;
+    const user = await UserModel.findOne({ email, type: loginType });
 
     if (!user) return done(null, false, { message: Message.InvalidEmail });
     if (!isComparedPassword(password, user?.get('password'))) {


### PR DESCRIPTION
### 작업 사항
- [x] mock 데이터 삭제하고 실제 DB의 유저정보와 비교하도록 변경
- [x] email, password 비교 방식에서 email, password, loginType 까지 같이 비교
- [x] 로그인 성공 시 해당 유저의 DB에 refresh token 저장하도록 변경


### 요약
- 처음에는 드라이버와 일반 사용자를 판별을 driver 속성의 값이 있는지 없는지로 구별하려 했지만 몽구스에서 값이 없으면 속성자체가 생성이 안되서 비교하는데 비효율적이라고 판단해서 type 속성을 추가하였습니다!
- type은 '일반 사용자', '드라이버' 중 하나의 값을 같도록 타입을 정의 하였습니다.
- 이메일 비밀번호가 일치해도 로그인 하려는 타입이 다를 경우 로그인 실패되도록 구현했습니다.


### 첨부
작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
#30 