### PR TITLE
[JH] API Auth 서버쪽 로직 구현

### DIFF
--- a/server/src/api/token/token.graphql
+++ b/server/src/api/token/token.graphql
@@ -1,0 +1,9 @@
+type requestTokenResponse {
+    result: Boolean!
+    accessToken: String
+    error: String
+}
+
+type Mutation {
+    requestToken: requestTokenResponse!
+}

--- a/server/src/api/token/token.resolvers.ts
+++ b/server/src/api/token/token.resolvers.ts
@@ -1,0 +1,47 @@
+import { AuthenticationError } from 'apollo-server-express';
+import { Resolvers } from '@type/api';
+import jwt from 'jsonwebtoken';
+import UserModel from '@models/user';
+
+type Token = string | undefined;
+
+interface SECRET_KEY {
+  JWT_SECRET_KEY?: string | undefined;
+}
+
+interface User {
+  email?: string;
+  iat?: number;
+  exp?: number;
+}
+
+const { JWT_SECRET_KEY }: SECRET_KEY = process.env;
+const JWT_INVALID = 'invalid token';
+
+const resolvers: Resolvers = {
+  Mutation: {
+    requestToken: async (root, args, context) => {
+      try {
+        const token: Token = context.req.headers.authorization?.replace('Bearer ', '');
+        const data = jwt.verify(token!, JWT_SECRET_KEY!, { ignoreExpiration: true }) as User;
+        const user = await UserModel.findOne({ email: data.email });
+        const isRefreshToken = user?.get('refreshToken');
+
+        if (isRefreshToken) {
+          const payload = { email: data?.email };
+          const newAccessToken = jwt.sign(payload, JWT_SECRET_KEY!, { expiresIn: '15m' });
+          const newRefreshToken = jwt.sign(payload, JWT_SECRET_KEY!, { expiresIn: '14d' });
+
+          await UserModel.updateOne({ email: data?.email }, { refreshToken: newRefreshToken });
+
+          return { result: true, accessToken: newAccessToken };
+        }
+        throw new AuthenticationError(JWT_INVALID);
+      } catch (error) {
+        throw new AuthenticationError(error);
+      }
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import dotenv from 'dotenv';
 
 import schema from '@config/schema';
 import loginRouter from '@api/login/index';
+import apiAuth from '@util/apiAuth';
 
 dotenv.config();
 
@@ -32,7 +33,7 @@ class App {
     this.app = express();
     this.apolloServer = new ApolloServer({
       schema,
-      context: (ctx) => ({ ...ctx, pubsub: this.pubsub }),
+      context: (ctx) => apiAuth(ctx, this.pubsub),
       playground: true,
     });
     this.server = createServer(this.app);

--- a/server/src/types/api.d.ts
+++ b/server/src/types/api.d.ts
@@ -23,6 +23,18 @@ export type Query = {
   hello: HelloResponse;
 };
 
+export type RequestTokenResponse = {
+  __typename?: 'requestTokenResponse';
+  result: Scalars['Boolean'];
+  accessToken?: Maybe<Scalars['String']>;
+  error?: Maybe<Scalars['String']>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  requestToken: RequestTokenResponse;
+};
+
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -104,7 +116,9 @@ export type ResolversTypes = {
   HelloResponse: ResolverTypeWrapper<HelloResponse>;
   String: ResolverTypeWrapper<Scalars['String']>;
   Query: ResolverTypeWrapper<{}>;
+  requestTokenResponse: ResolverTypeWrapper<RequestTokenResponse>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Mutation: ResolverTypeWrapper<{}>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -112,7 +126,9 @@ export type ResolversParentTypes = {
   HelloResponse: HelloResponse;
   String: Scalars['String'];
   Query: {};
+  requestTokenResponse: RequestTokenResponse;
   Boolean: Scalars['Boolean'];
+  Mutation: {};
 };
 
 export type HelloResponseResolvers<ContextType = {
@@ -133,6 +149,25 @@ export type QueryResolvers<ContextType = {
   hello?: Resolver<ResolversTypes['HelloResponse'], ParentType, ContextType>;
 };
 
+export type RequestTokenResponseResolvers<ContextType = {
+  req: Request,
+  pubsub: PubSub
+}
+, ParentType extends ResolversParentTypes['requestTokenResponse'] = ResolversParentTypes['requestTokenResponse']> = {
+  result?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  accessToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MutationResolvers<ContextType = {
+  req: Request,
+  pubsub: PubSub
+}
+, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  requestToken?: Resolver<ResolversTypes['requestTokenResponse'], ParentType, ContextType>;
+};
+
 export type Resolvers<ContextType = {
   req: Request,
   pubsub: PubSub
@@ -140,6 +175,8 @@ export type Resolvers<ContextType = {
 > = {
   HelloResponse?: HelloResponseResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  requestTokenResponse?: RequestTokenResponseResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
 };
 
 

--- a/server/src/util/apiAuth.ts
+++ b/server/src/util/apiAuth.ts
@@ -1,0 +1,39 @@
+import { AuthenticationError } from 'apollo-server-express';
+import jwt from 'jsonwebtoken';
+import { ExpressContext } from 'apollo-server-express/dist/ApolloServer';
+import { PubSub } from 'graphql-subscriptions';
+
+interface SECRET_KEY {
+  JWT_SECRET_KEY?: string | undefined;
+}
+
+interface User {
+  email?: string;
+  iat?: number;
+  exp?: number;
+}
+
+const { JWT_SECRET_KEY }: SECRET_KEY = process.env;
+const REQUEST_TOKEN = 'requestToken';
+
+const apiAuth = (ctx: ExpressContext, pubsub: PubSub) => {
+  const { query } = ctx.req.body;
+  const isRequestTokenMutation = query.split('\n')[1].includes(REQUEST_TOKEN);
+  const accessToken: string | undefined = ctx.req.headers.authorization?.replace('Bearer ', '');
+
+  if (!isRequestTokenMutation) {
+    try {
+      const data = jwt.verify(accessToken!, JWT_SECRET_KEY!) as User;
+      ctx.req.user = data.email;
+
+      return { ...ctx, pubsub };
+    } catch (error) {
+      const { message } = error;
+      throw new AuthenticationError(message);
+    }
+  }
+
+  return { ...ctx, pubsub };
+};
+
+export default apiAuth;


### PR DESCRIPTION
### 작업 사항
- [x] accessToken 유효기간이 지났을 경우 재발급 요청하면 유효성 검사 후 재발급하도록 구현


### 요약
accessToken이 유효하지 않을 경우, accessToken을 클라이언트에서 보내주지 않았을 경우, accessToken 재발급 요청을 하는 경우 모두 처리하도록 구현했습니다.


### 첨부
작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
#35 