### PR TITLE
[JE] 메뉴 헤더 구현

### DIFF
--- a/client/src/components/HeaderWithBack/HeaderWithBack.tsx
+++ b/client/src/components/HeaderWithBack/HeaderWithBack.tsx
@@ -5,12 +5,15 @@ import LeftSVG from '@images/LeftSVG';
 
 interface Props {
   onClick: () => void;
+  className?: string;
 }
 
 const StyledHeaderWithBack = styled.header`
   display: flex;
-  margin-left: 1.5rem;
   height: 3rem;
+  width: 100%;
+  background-color: ${({ className, theme }) =>
+    className === 'green-header' ? theme.PRIMARY : '#ffffff'};
 
   & button {
     background: none;
@@ -21,11 +24,12 @@ const StyledHeaderWithBack = styled.header`
   & svg {
     width: 1.5rem;
     fill: ${({ theme }) => theme.PRIMARY};
+    margin-left: 1.5rem;
   }
 `;
 
-const HeaderWithBack: FC<Props> = ({ onClick }) => (
-  <StyledHeaderWithBack>
+const HeaderWithBack: FC<Props> = ({ onClick, className }) => (
+  <StyledHeaderWithBack className={className}>
     <button type="button" onClick={onClick}>
       <LeftSVG />
     </button>

--- a/client/src/components/HeaderWithBack/HeaderWithBack.tsx
+++ b/client/src/components/HeaderWithBack/HeaderWithBack.tsx
@@ -28,7 +28,7 @@ const StyledHeaderWithBack = styled.header`
   }
 `;
 
-const HeaderWithBack: FC<Props> = ({ onClick, className }) => (
+const HeaderWithBack: FC<Props> = ({ onClick, className = 'white-header' }) => (
   <StyledHeaderWithBack className={className}>
     <button type="button" onClick={onClick}>
       <LeftSVG />

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
+import useToggle from '@hooks/useToggle';
 
 import styled from '@theme/styled';
 import MenuSVG from '@images/menuSVG.tsx';
 
 interface Props {
-  onClick: () => void;
   className?: string;
 }
 
-const StyledHeaderWithMenu = styled.header`
+const StyledHeaderWithMenu = styled.header<{ isMenuOpen: boolean }>`
   display: flex;
   height: 3rem;
   width: 100%;
@@ -26,14 +26,37 @@ const StyledHeaderWithMenu = styled.header`
     fill: #ffffff;
     margin-left: 1.5rem;
   }
+
+  & menu {
+    position: absolute;
+    top: 3rem;
+    left: 0;
+    visibility: ${(props) => (props.isMenuOpen ? 'visible' : 'hidden')};
+    width: ${(props) => (props.isMenuOpen ? '100%' : '0')};
+    height: calc(100vh - 3rem);
+    z-index: 1;
+    padding: 1rem 1rem;
+    background-color: #ffffff;
+    border-right: 1px solid ${({ theme }) => theme.PRIMARY};
+    transition: 0.5s;
+  }
 `;
 
-const HeaderWithMenu: FC<Props> = ({ onClick, className }) => (
-  <StyledHeaderWithMenu className={className}>
-    <button type="button" onClick={onClick}>
-      <MenuSVG />
-    </button>
-  </StyledHeaderWithMenu>
-);
+const HeaderWithMenu: FC<Props> = ({ className }) => {
+  const [menu, toggleMenu] = useToggle(false);
+
+  return (
+    <StyledHeaderWithMenu className={className} isMenuOpen={menu}>
+      <button type="button" onClick={toggleMenu}>
+        <MenuSVG />
+      </button>
+      <menu>
+        <ul>
+          <li>마이페이지</li>
+        </ul>
+      </menu>
+    </StyledHeaderWithMenu>
+  );
+};
 
 export default HeaderWithMenu;

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -42,7 +42,7 @@ const StyledHeaderWithMenu = styled.header<{ isMenuOpen: boolean }>`
   }
 `;
 
-const HeaderWithMenu: FC<Props> = ({ className }) => {
+const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
   const [menu, toggleMenu] = useToggle(false);
 
   return (

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+
+import styled from '@theme/styled';
+import MenuSVG from '@images/menuSVG.tsx';
+
+interface Props {
+  onClick: () => void;
+  className?: string;
+}
+
+const StyledHeaderWithMenu = styled.header`
+  display: flex;
+  height: 3rem;
+  width: 100%;
+  background-color: ${({ className, theme }) =>
+    className === 'green-header' ? theme.PRIMARY : '#ffffff'};
+
+  & button {
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  & svg {
+    width: 1.5rem;
+    fill: #ffffff;
+    margin-left: 1.5rem;
+  }
+`;
+
+const HeaderWithMenu: FC<Props> = ({ onClick, className }) => (
+  <StyledHeaderWithMenu className={className}>
+    <button type="button" onClick={onClick}>
+      <MenuSVG />
+    </button>
+  </StyledHeaderWithMenu>
+);
+
+export default HeaderWithMenu;

--- a/client/src/components/HeaderWithMenu/index.tsx
+++ b/client/src/components/HeaderWithMenu/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './HeaderWithMenu';

--- a/client/src/hooks/useToggle.ts
+++ b/client/src/hooks/useToggle.ts
@@ -1,0 +1,16 @@
+import { useState, useCallback } from 'react';
+
+const useToggle = (
+  initialValue: boolean,
+): [boolean, () => void, React.Dispatch<React.SetStateAction<boolean>>] => {
+  const [value, setValue] = useState(initialValue);
+
+  const onToggle = useCallback(() => {
+    // eslint-disable-next-line no-shadow
+    setValue((value) => !value);
+  }, []);
+
+  return [value, onToggle, setValue];
+};
+
+export default useToggle;

--- a/client/src/images/menuSVG.tsx
+++ b/client/src/images/menuSVG.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+
+const LeftSVG: FC = () => (
+  <svg viewBox="0 0 100 80" width="40" height="40">
+    <rect width="100" height="15" rx="10"></rect>
+    <rect y="30" width="100" height="15" rx="10"></rect>
+    <rect y="60" width="100" height="15" rx="10"></rect>
+  </svg>
+);
+
+export default LeftSVG;


### PR DESCRIPTION
### 작업 사항
- [x] state를 toggle하는 hook 구현
- [x] 메뉴 헤더 구현
- [x] 메뉴에 background 색을 줄 수 있도록 수정
- [x] 메뉴 버튼 누르면 메뉴가 slide되어서 나오도록 구현

### 요약
앞으로 구현할 페이지에서 사용할 메뉴 헤더를 구현했습니다.
메뉴 버튼을 누르면 slide되어서 메뉴가 나오도록 했습니다.
지금은 움직임이 살짝 부자연스럽습니다.

### 첨부
![ezgif com-gif-maker](https://user-images.githubusercontent.com/43084680/100303070-0d29fc80-2fdf-11eb-8b3e-937b294d91e2.gif)


### 이슈
#59 