### PR TITLE
[JH, CY, JE, HJ] useQuery, useMutation 커스텀 훅 구현

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-use-before-define': 0,
     'import/no-unresolved': 0,
     'import/no-extraneous-dependencies': 0,
+    'consistent-return': 0,
   },
   settings: {
     'import/resolver': {

--- a/client/src/hooks/useApollo.ts
+++ b/client/src/hooks/useApollo.ts
@@ -13,8 +13,6 @@ import {
 } from '@apollo/react-hooks';
 import { DocumentNode } from 'graphql';
 import { REQUEST_TOKEN } from '@queries/token.queries';
-import { useHistory } from 'react-router-dom';
-import { History } from 'history';
 
 import { RequestToken } from '@/types/api';
 
@@ -28,17 +26,14 @@ const errorHandler = async (
   error: ApolloError,
   apolloClient: ApolloClient<any>,
   request: (...args: any) => any,
-  history: History,
 ) => {
   const { statusCode } = error.networkError as ServerParseError;
   if (statusCode === 401) {
     const result = await apolloClient.mutate<RequestToken>({ mutation: REQUEST_TOKEN });
     if (result?.data?.requestToken.result === SUCCESS) {
       const reResponseData = await request();
-
       return reResponseData;
     }
-    history.push('/signin');
   }
   return undefined;
 };
@@ -48,11 +43,10 @@ export const useCustomQuery = <T = any>(
   options?: QueryHookOptions<T>,
 ): QueryWrapper => {
   const apolloClient = useApolloClient();
-  const history = useHistory();
   const queryResult = useQuery<T>(query, {
     ...options,
     onError: (error: ApolloError) => {
-      errorHandler(error, apolloClient, queryResult.refetch, history).then(() => {
+      errorHandler(error, apolloClient, queryResult.refetch).then(() => {
         if (options?.onError) {
           options.onError(error);
         }
@@ -64,7 +58,7 @@ export const useCustomQuery = <T = any>(
     try {
       return await queryResult.refetch(variables);
     } catch (error) {
-      const result = await errorHandler(error, apolloClient, queryResult.refetch, history);
+      const result = await errorHandler(error, apolloClient, queryResult.refetch);
       return result;
     }
   };
@@ -77,11 +71,10 @@ export const useCustomMutation = <T = any>(
   options?: MutationHookOptions<T>,
 ): MutationTuple<T, Record<string, any>> => {
   const apolloClient = useApolloClient();
-  const history = useHistory();
   const mutationTuple = useMutation<T>(query, {
     ...options,
     onError: (error: ApolloError) => {
-      errorHandler(error, apolloClient, mutationTuple[0], history).then(() => {
+      errorHandler(error, apolloClient, mutationTuple[0]).then(() => {
         if (options?.onError) {
           options.onError(error);
         }

--- a/client/src/hooks/useApollo.ts
+++ b/client/src/hooks/useApollo.ts
@@ -1,0 +1,70 @@
+import {
+  useApolloClient,
+  useQuery,
+  QueryHookOptions,
+  ApolloError,
+  ServerParseError,
+  QueryResult,
+  ApolloClient,
+  ApolloQueryResult,
+} from '@apollo/react-hooks';
+import { DocumentNode } from 'graphql';
+import { REQUEST_TOKEN } from '@queries/token.queries';
+import { useHistory } from 'react-router-dom';
+import { History } from 'history';
+
+import { RequestToken } from '@/types/api';
+
+const SUCCESS = 'success';
+
+interface QueryWrapper extends QueryResult<any, Record<string, any>> {
+  callQuery: (variables?: any) => Promise<ApolloQueryResult<any> | undefined>;
+}
+
+const errorHandler = async (
+  error: ApolloError,
+  apolloClient: ApolloClient<any>,
+  queryResult: QueryResult<any, Record<string, any>>,
+  history: History,
+) => {
+  const { statusCode } = error.networkError as ServerParseError;
+  if (statusCode === 401) {
+    const result = await apolloClient.mutate<RequestToken>({ mutation: REQUEST_TOKEN });
+    if (result?.data?.requestToken.result === SUCCESS) {
+      const reResponseData = await queryResult.refetch();
+
+      return reResponseData;
+    }
+    history.push('/signin');
+  }
+  return undefined;
+};
+
+export const useCustomQuery = <T = any>(
+  query: DocumentNode,
+  options?: QueryHookOptions,
+): QueryWrapper => {
+  const apolloClient = useApolloClient();
+  const history = useHistory();
+  const queryResult = useQuery(query, {
+    ...options,
+    onError: (error: ApolloError) => {
+      errorHandler(error, apolloClient, queryResult, history).then(() => {
+        if (options?.onError) {
+          options.onError(error);
+        }
+      });
+    },
+  });
+
+  const callQuery = async (variables?: any) => {
+    try {
+      return await queryResult.refetch(variables);
+    } catch (error) {
+      const result = await errorHandler(error, apolloClient, queryResult, history);
+      return result;
+    }
+  };
+
+  return { ...queryResult, callQuery };
+};

--- a/client/src/queries/token.queries.ts
+++ b/client/src/queries/token.queries.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const REQUEST_TOKEN = gql`
+  mutation RequestToken {
+    requestToken {
+      result
+      message
+    }
+  }
+`;

--- a/client/src/utils/auth.tsx
+++ b/client/src/utils/auth.tsx
@@ -1,17 +1,17 @@
 import React, { FC, useState } from 'react';
-import { useQuery } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
 import { Modal } from 'antd-mobile';
 
 import { GET_USER_INFO } from '@queries/user.queries';
 import { GetUserInfo } from '@/types/api';
+import { useCustomQuery } from '@hooks/useApollo';
 
 const AUTH_MESSAGE = '로그인이 필요합니다';
 
 const auth = (Component: FC): FC => () => {
   const [modalOpen, setModalOpen] = useState(false);
   const history = useHistory();
-  const { loading } = useQuery<GetUserInfo>(GET_USER_INFO, {
+  const { loading } = useCustomQuery<GetUserInfo>(GET_USER_INFO, {
     onCompleted: ({ getUserInfo }) => {
       if (!getUserInfo.user) {
         setModalOpen(true);

--- a/server/src/api/token/token.graphql
+++ b/server/src/api/token/token.graphql
@@ -1,0 +1,8 @@
+type requestTokenResponse {
+    result: String!
+    message: String
+}
+
+type Mutation {
+    requestToken: requestTokenResponse!
+}

--- a/server/src/api/token/token.resolvers.ts
+++ b/server/src/api/token/token.resolvers.ts
@@ -38,7 +38,6 @@ const resolvers: Resolvers = {
 
         return { result: 'fail' };
       } catch (error) {
-        console.log(error);
         return { result: 'fail', message: error.message };
       }
     },

--- a/server/src/api/token/token.resolvers.ts
+++ b/server/src/api/token/token.resolvers.ts
@@ -1,0 +1,48 @@
+import { Resolvers } from '@type/api';
+import jwt from 'jsonwebtoken';
+import UserModel from '@models/user';
+
+interface User {
+  id?: string;
+  iat?: number;
+  exp?: number;
+}
+
+const JWT_SECRET_KEY = process.env.JWT_SECRET_KEY as string;
+const JWT_HEADER = process.env.JWT_HEADER as string;
+const EXPIRED = 1000 * 60 * 60 * 24 * 14;
+
+const resolvers: Resolvers = {
+  Mutation: {
+    requestToken: async (root, args, context) => {
+      try {
+        const token = context.req.cookies[JWT_HEADER];
+        const data = jwt.verify(token, JWT_SECRET_KEY, { ignoreExpiration: true }) as User;
+        const user = await UserModel.findById(data.id);
+        const userRefreshToken = user?.get('refreshToken');
+        const isRefreshToken = jwt.verify(userRefreshToken, JWT_SECRET_KEY);
+
+        if (isRefreshToken) {
+          const payload = { id: data?.id };
+          const newAccessToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '15m' });
+          const newRefreshToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '14d' });
+
+          await UserModel.updateOne({ id: data?.id }, { refreshToken: newRefreshToken });
+          context.res.cookie(JWT_HEADER, newAccessToken, {
+            httpOnly: true,
+            maxAge: EXPIRED,
+          });
+
+          return { result: 'success' };
+        }
+
+        return { result: 'fail' };
+      } catch (error) {
+        console.log(error);
+        return { result: 'fail', message: error.message };
+      }
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/user/login/login.resolvers.ts
+++ b/server/src/api/user/login/login.resolvers.ts
@@ -5,7 +5,7 @@ import UserModel from '@models/user';
 const JWT_SECRET_KEY = process.env.JWT_SECRET_KEY as string;
 const JWT_HEADER = process.env.JWT_HEADER as string;
 
-const EXPIRED = 1000 * 60 * 15;
+const EXPIRED = 1000 * 60 * 60 * 24 * 14;
 
 const resolvers: Resolvers = {
   Mutation: {
@@ -15,14 +15,14 @@ const resolvers: Resolvers = {
       if (!user) return { result: 'fail', error: info?.message };
       const userId = user?.get('_id');
       const payload = { id: userId };
-      const accessToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '15m' });
+      const accessToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '3s' });
       const refreshToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '14d' });
 
       await UserModel.updateOne({ _id: userId }, { refreshToken });
 
       res.cookie(JWT_HEADER, accessToken, {
         httpOnly: true,
-        expires: new Date(Date.now() + EXPIRED),
+        maxAge: EXPIRED,
       });
 
       return { result: 'success' };

--- a/server/src/api/user/login/login.resolvers.ts
+++ b/server/src/api/user/login/login.resolvers.ts
@@ -15,7 +15,7 @@ const resolvers: Resolvers = {
       if (!user) return { result: 'fail', error: info?.message };
       const userId = user?.get('_id');
       const payload = { id: userId };
-      const accessToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '3s' });
+      const accessToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '15m' });
       const refreshToken = jwt.sign(payload, JWT_SECRET_KEY, { expiresIn: '14d' });
 
       await UserModel.updateOne({ _id: userId }, { refreshToken });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,6 @@ import compression from 'compression';
 import morgan from 'morgan';
 import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
-import expressSession from 'express-session';
 import { buildContext } from 'graphql-passport';
 
 import schema from '@config/schema';

--- a/server/src/util/isAuthenticated.ts
+++ b/server/src/util/isAuthenticated.ts
@@ -20,7 +20,7 @@ class IsAuthenticatedDirective extends SchemaDirectiveVisitor {
 
       await new Promise((resFn) => {
         passport.authenticate('jwt', (error, payload, { message } = {}) => {
-          if (error || !payload) return res.status(400).send({ result: 'fail', message });
+          if (error || !payload) return res.status(401).send({ data: { result: 'fail', message } });
           req.user = payload?.get('_id');
           resFn();
         })(req, res);


### PR DESCRIPTION
### 작업 사항
- [x] useQuery 커스텀 훅 구현
- [x] useMutation 커스텀 훅 구현
- [x] 서버 API 토큰 재발급 로직 구현

### 요약
- 클라이언트에서 query, mutation 요청 시 토큰 검사 및 토큰 재발급 그리고 이전 요청까지 모두 동작하도록 custom Hooks 로 구현했습니다~


### 첨부
작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
#43 