### PR TITLE
[CY] 맵 컴포넌트 위치 이동 리팩터링

### DIFF
--- a/client/src/components/GoogleMap/Directions.tsx
+++ b/client/src/components/GoogleMap/Directions.tsx
@@ -13,10 +13,10 @@ const Directions: FC<Props> = ({ origin, destination }) => {
   const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
   const count = useRef(0);
 
-  const options = {
+  const options: google.maps.DirectionsRendererOptions = {
     polylineOptions: {
       strokeColor: 'red',
-      strockeWeight: 10,
+      strokeWeight: 4,
       strokeOpacity: 0.8,
     },
   };
@@ -38,7 +38,7 @@ const Directions: FC<Props> = ({ origin, destination }) => {
   return (
     <>
       <DirectionsService
-        options={{ origin, destination, travelMode: 'BICYCLING' as any }}
+        options={{ origin, destination, travelMode: 'BICYCLING' as google.maps.TravelMode }}
         callback={directionsCallback}
       />
       <DirectionsRenderer directions={directions} options={options} />

--- a/client/src/components/GoogleMap/GoogleMap.tsx
+++ b/client/src/components/GoogleMap/GoogleMap.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState, useEffect, useCallback } from 'react';
 
 import { GoogleMap as GoogleMapComponent, Marker } from '@react-google-maps/api';
+import getUserLocation from '@utils/getUserLocation';
 
 import Directions from './Directions';
 
@@ -38,15 +39,10 @@ const GoogleMap: FC<Props> = ({ origin, destination }) => {
       return;
     }
 
-    const currentLocation = await new Promise<Location>((res) => {
-      window.navigator.geolocation.getCurrentPosition((position) => {
-        res({
-          lat: position.coords.latitude,
-          lng: position.coords.longitude,
-        });
-      });
-    });
-    setCenter(currentLocation);
+    const currentLocation = await getUserLocation();
+    if (currentLocation) {
+      setCenter(currentLocation);
+    }
   }, [origin, destination]);
 
   useEffect(() => {

--- a/client/src/components/GoogleMap/GoogleMap.tsx
+++ b/client/src/components/GoogleMap/GoogleMap.tsx
@@ -21,7 +21,8 @@ const containerStyle = {
 };
 
 const GoogleMap: FC<Props> = ({ origin, destination }) => {
-  const [center, setCenter] = useState({ lat: 0, lng: 0 });
+  const [isInitLoad, setIsInitLoad] = useState(true);
+  const [center, setCenter] = useState<Location>();
 
   const setCenterHandler = useCallback(async () => {
     if (origin && destination) {
@@ -46,12 +47,17 @@ const GoogleMap: FC<Props> = ({ origin, destination }) => {
   }, [origin, destination]);
 
   useEffect(() => {
-    const centerInterval = setInterval(setCenterHandler, 5000);
-
-    return () => {
-      clearInterval(centerInterval);
-    };
+    if (isInitLoad) {
+      setTimeout(setCenterHandler, 100);
+      setIsInitLoad(false);
+    }
   }, []);
+
+  useEffect(() => {
+    if (!isInitLoad) {
+      setTimeout(setCenterHandler, 100);
+    }
+  }, [origin, destination]);
 
   const onLoad = React.useCallback((map) => {
     const bounds = new window.google.maps.LatLngBounds();

--- a/client/src/utils/getUserLocation.ts
+++ b/client/src/utils/getUserLocation.ts
@@ -1,0 +1,24 @@
+import { Location } from '@components/GoogleMap';
+
+const getUserLocation = async (): Promise<Location | void> => {
+  try {
+    const userLocation = await new Promise<Location>((res, rej) => {
+      window.navigator.geolocation.getCurrentPosition(
+        (position) => {
+          res({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          });
+        },
+        (err) => {
+          rej(err);
+        },
+      );
+    });
+    return userLocation;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default getUserLocation;


### PR DESCRIPTION
### 작업 사항
- [x] 유저 위치 조회 함수 분리 리팩터링
- [x] 구글 맵 center 이동 최적화
  - 매 초마다 center 이동 제거 (추후 실시간 위치 공유에서 다시 적용할 예정)
  - 초기 위치 로딩 시간 setTimeout으로 100ms으로 늦춤 (초기 위치가 비동기로 동작, 너무 빨라서 리액트가 상태 변경을 감지 못함)

### 요약
전체적인 맵 컴포넌트 위치 변경 속도 최적화

### 이슈
#70 