### PR TITLE
[JH] 채팅 페이지 View 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,7 +29,6 @@ const App: FC = () => (
             <Route exact path="/" component={auth(Home)} />
             <Route exact path="/signin" component={SignIn} />
             <Route exact path="/signup" component={Signup} />
-            <Route exact path="/signup" component={Signup} />
             <Route exact path="/chatroom" component={auth(ChatRoom)} />
           </Switch>
         </BrowserRouter>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { ApolloProvider } from '@apollo/react-hooks';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
+import ChatRoom from '@routes/ChatRoom';
 import SignIn from '@/routes/SignIn';
 import Home from '@routes/Home';
 import Signup from '@routes/Signup';
@@ -28,6 +29,8 @@ const App: FC = () => (
             <Route exact path="/" component={auth(Home)} />
             <Route exact path="/signin" component={SignIn} />
             <Route exact path="/signup" component={Signup} />
+            <Route exact path="/signup" component={Signup} />
+            <Route exact path="/chatroom" component={auth(ChatRoom)} />
           </Switch>
         </BrowserRouter>
       </ThemeProvider>

--- a/client/src/components/ChatInput/ChatInput.tsx
+++ b/client/src/components/ChatInput/ChatInput.tsx
@@ -34,17 +34,15 @@ const ChatInput: FC = () => {
   const [chatContent, , onChangeChatContent] = useChange('');
 
   return (
-    <>
-      <StyledChatInput>
-        <Input
-          type="text"
-          placeholder="채팅을 입력해 주세요."
-          value={chatContent}
-          onChange={onChangeChatContent}
-        ></Input>
-        <Button type="primary">전송</Button>
-      </StyledChatInput>
-    </>
+    <StyledChatInput>
+      <Input
+        type="text"
+        placeholder="채팅을 입력해 주세요."
+        value={chatContent}
+        onChange={onChangeChatContent}
+      ></Input>
+      <Button type="primary">전송</Button>
+    </StyledChatInput>
   );
 };
 

--- a/client/src/components/ChatInput/ChatInput.tsx
+++ b/client/src/components/ChatInput/ChatInput.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react';
+
+import Input from '@components/Input';
+import { Button } from 'antd-mobile';
+import styled from '@theme/styled';
+import useChange from '@hooks/useChange';
+
+const StyledChatInput = styled.div`
+  display: flex;
+  align-items: center;
+  position: sticky;
+  bottom: 0;
+  padding: 0.5rem;
+
+  & > div {
+    width: 80%;
+    margin-right: 0.5rem;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+  }
+
+  & > a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20%;
+    height: 2.1rem;
+    font-weight: 700;
+    font-size: 0.9rem;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+  }
+`;
+
+const ChatInput: FC = () => {
+  const [chatContent, , onChangeChatContent] = useChange('');
+
+  return (
+    <>
+      <StyledChatInput>
+        <Input
+          type="text"
+          placeholder="채팅을 입력해 주세요."
+          value={chatContent}
+          onChange={onChangeChatContent}
+        ></Input>
+        <Button type="primary">전송</Button>
+      </StyledChatInput>
+    </>
+  );
+};
+
+export default ChatInput;

--- a/client/src/components/ChatInput/index.ts
+++ b/client/src/components/ChatInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatInput';

--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+
+import styled from '@theme/styled';
+
+interface Props {
+  writer: string;
+  content: string;
+  createdAt: string;
+  type: string;
+}
+
+interface Type {
+  type: string;
+}
+
+const StyledChatLogWrapper = styled.div<Type>`
+  display: flex;
+  justify-content: ${({ type }) => (type === 'me' ? 'flex-end' : 'flex-start')};
+  padding: 0.5rem;
+`;
+
+const StyledChatLog = styled.span<Type>`
+  padding: 0.6rem 1rem;
+  background-color: ${({ theme, type }) => (type === 'me' ? theme.PRIMARY : theme.BORDER)};
+  color: ${({ theme }) => theme.LIGHT};
+  border-radius: 0.4rem;
+`;
+
+const ChatLog: FC<Props> = ({ content, createdAt, writer, type }) => {
+  return (
+    <>
+      <StyledChatLogWrapper type={type}>
+        <StyledChatLog type={type}>{content}</StyledChatLog>
+      </StyledChatLogWrapper>
+    </>
+  );
+};
+
+export default ChatLog;

--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -17,19 +17,19 @@ const StyledChatLogWrapper = styled.div<Type>`
   display: flex;
   justify-content: ${({ type }) => (type === 'me' ? 'flex-end' : 'flex-start')};
   padding: 0.5rem;
-`;
 
-const StyledChatLog = styled.span<Type>`
-  padding: 0.6rem 1rem;
-  background-color: ${({ theme, type }) => (type === 'me' ? theme.PRIMARY : theme.BORDER)};
-  color: ${({ theme }) => theme.LIGHT};
-  border-radius: 0.4rem;
+  & > .chat-content {
+    padding: 0.6rem 1rem;
+    background-color: ${({ theme, type }) => (type === 'me' ? theme.PRIMARY : theme.BORDER)};
+    color: ${({ theme }) => theme.LIGHT};
+    border-radius: 0.4rem;
+  }
 `;
 
 const ChatLog: FC<Props> = ({ content, createdAt, writer, type }) => {
   return (
     <StyledChatLogWrapper type={type}>
-      <StyledChatLog type={type}>{content}</StyledChatLog>
+      <span className="chat-content">{content}</span>
     </StyledChatLogWrapper>
   );
 };

--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -28,11 +28,9 @@ const StyledChatLog = styled.span<Type>`
 
 const ChatLog: FC<Props> = ({ content, createdAt, writer, type }) => {
   return (
-    <>
-      <StyledChatLogWrapper type={type}>
-        <StyledChatLog type={type}>{content}</StyledChatLog>
-      </StyledChatLogWrapper>
-    </>
+    <StyledChatLogWrapper type={type}>
+      <StyledChatLog type={type}>{content}</StyledChatLog>
+    </StyledChatLogWrapper>
   );
 };
 

--- a/client/src/components/ChatLog/index.ts
+++ b/client/src/components/ChatLog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatLog';

--- a/client/src/components/HeaderWithBack/HeaderWithBack.tsx
+++ b/client/src/components/HeaderWithBack/HeaderWithBack.tsx
@@ -23,7 +23,7 @@ const StyledHeaderWithBack = styled.header`
 
   & svg {
     width: 1.5rem;
-    fill: ${({ theme }) => theme.PRIMARY};
+    fill: ${({ className, theme }) => (className === 'green-header' ? theme.LIGHT : theme.PRIMARY)};
     margin-left: 1.5rem;
   }
 `;

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -174,17 +174,15 @@ const ChatRoom: FC = () => {
   };
 
   return (
-    <>
-      <StyledChatRoom>
-        <HeaderWithBack onClick={onClickBackButton} className="green-header" />
-        <StyledChatMain>
-          {Chat.map((item) => (
-            <ChatLog key={item.id} {...item}></ChatLog>
-          ))}
-        </StyledChatMain>
-        <ChatInput></ChatInput>
-      </StyledChatRoom>
-    </>
+    <StyledChatRoom>
+      <HeaderWithBack onClick={onClickBackButton} className="green-header" />
+      <StyledChatMain>
+        {Chat.map((item) => (
+          <ChatLog key={item.id} {...item}></ChatLog>
+        ))}
+      </StyledChatMain>
+      <ChatInput></ChatInput>
+    </StyledChatRoom>
   );
 };
 

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -176,10 +176,10 @@ const ChatRoom: FC = () => {
   return (
     <>
       <StyledChatRoom>
-        <HeaderWithBack onClick={onClickBackButton} className="green-header"></HeaderWithBack>
+        <HeaderWithBack onClick={onClickBackButton} className="green-header" />
         <StyledChatMain>
           {Chat.map((item) => (
-            <ChatLog {...item}></ChatLog>
+            <ChatLog key={item.id} {...item}></ChatLog>
           ))}
         </StyledChatMain>
         <ChatInput></ChatInput>

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -1,0 +1,191 @@
+import React, { FC } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import HeaderWithBack from '@components/HeaderWithBack';
+import ChatLog from '@components/ChatLog';
+import ChatInput from '@components/ChatInput';
+import styled from '@theme/styled';
+
+const Chat = [
+  {
+    id: 0,
+    createdAt: '2020-11-28 18:46:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '안녕하세요. 빨리 가겠습니다. 좀만 기다려 주세요~',
+    type: 'driver',
+  },
+  {
+    id: 1,
+    createdAt: '2020-11-28 18:47:23',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네네 천천히 오세요 ㅎㅎ',
+    type: 'me',
+  },
+  {
+    id: 2,
+    createdAt: '2020-11-28 18:48:28',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '거의 다 도착했습니다. 탑승 준비해주세요!',
+    type: 'driver',
+  },
+  {
+    id: 3,
+    createdAt: '2020-11-28 18:49:40',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네 지금 출발지 앞에서 기다리고 있어요!',
+    type: 'me',
+  },
+  {
+    id: 4,
+    createdAt: '2020-11-28 18:51:40',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '도착했습니다! 어디신가요?',
+    type: 'driver',
+  },
+  {
+    id: 5,
+    createdAt: '2020-11-28 18:52:20',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '아 저기 보이네요! 이제 갈게요',
+    type: 'me',
+  },
+  {
+    id: 6,
+    createdAt: '2020-11-28 18:53:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '네 알겠습니다~ 안전하게 모실게요',
+    type: 'driver',
+  },
+  {
+    id: 0,
+    createdAt: '2020-11-28 18:46:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '안녕하세요. 빨리 가겠습니다. 좀만 기다려 주세요~',
+    type: 'driver',
+  },
+  {
+    id: 1,
+    createdAt: '2020-11-28 18:47:23',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네네 천천히 오세요 ㅎㅎ',
+    type: 'me',
+  },
+  {
+    id: 2,
+    createdAt: '2020-11-28 18:48:28',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '거의 다 도착했습니다. 탑승 준비해주세요!',
+    type: 'driver',
+  },
+  {
+    id: 3,
+    createdAt: '2020-11-28 18:49:40',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네 지금 출발지 앞에서 기다리고 있어요!',
+    type: 'me',
+  },
+  {
+    id: 4,
+    createdAt: '2020-11-28 18:51:40',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '도착했습니다! 어디신가요?',
+    type: 'driver',
+  },
+  {
+    id: 5,
+    createdAt: '2020-11-28 18:52:20',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '아 저기 보이네요! 이제 갈게요',
+    type: 'me',
+  },
+  {
+    id: 6,
+    createdAt: '2020-11-28 18:53:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '네 알겠습니다~ 안전하게 모실게요',
+    type: 'driver',
+  },
+  {
+    id: 0,
+    createdAt: '2020-11-28 18:46:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '안녕하세요. 빨리 가겠습니다. 좀만 기다려 주세요~',
+    type: 'driver',
+  },
+  {
+    id: 1,
+    createdAt: '2020-11-28 18:47:23',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네네 천천히 오세요 ㅎㅎ',
+    type: 'me',
+  },
+  {
+    id: 2,
+    createdAt: '2020-11-28 18:48:28',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '거의 다 도착했습니다. 탑승 준비해주세요!',
+    type: 'driver',
+  },
+  {
+    id: 3,
+    createdAt: '2020-11-28 18:49:40',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '네 지금 출발지 앞에서 기다리고 있어요!',
+    type: 'me',
+  },
+  {
+    id: 4,
+    createdAt: '2020-11-28 18:51:40',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '도착했습니다! 어디신가요?',
+    type: 'driver',
+  },
+  {
+    id: 5,
+    createdAt: '2020-11-28 18:52:20',
+    writer: '5fbc9eacadc14b373c78f376',
+    content: '아 저기 보이네요! 이제 갈게요',
+    type: 'me',
+  },
+  {
+    id: 6,
+    createdAt: '2020-11-28 18:53:00',
+    writer: '5fc21d7f189d411e6cb67e10',
+    content: '네 알겠습니다~ 안전하게 모실게요',
+    type: 'driver',
+  },
+];
+
+const StyledChatRoom = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledChatMain = styled.div`
+  flex-grow: 1;
+  overflow: scroll;
+`;
+
+const ChatRoom: FC = () => {
+  const history = useHistory();
+  const onClickBackButton = () => {
+    history.push('/signin');
+  };
+
+  return (
+    <>
+      <StyledChatRoom>
+        <HeaderWithBack onClick={onClickBackButton} className="green-header"></HeaderWithBack>
+        <StyledChatMain>
+          {Chat.map((item) => (
+            <ChatLog {...item}></ChatLog>
+          ))}
+        </StyledChatMain>
+        <ChatInput></ChatInput>
+      </StyledChatRoom>
+    </>
+  );
+};
+
+export default ChatRoom;

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -178,7 +178,7 @@ const ChatRoom: FC = () => {
       <HeaderWithBack onClick={onClickBackButton} className="green-header" />
       <StyledChatMain>
         {Chat.map((item) => (
-          <ChatLog key={item.id} {...item}></ChatLog>
+          <ChatLog key={`chat_${item.id}`} {...item}></ChatLog>
         ))}
       </StyledChatMain>
       <ChatInput></ChatInput>

--- a/client/src/routes/ChatRoom/index.ts
+++ b/client/src/routes/ChatRoom/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatRoom';


### PR DESCRIPTION
### 작업 사항
- [x] 채팅 페이지 레이아웃 및 컴포넌트 구현
- [x] HeaderWithBack 컴포넌트 'green-header' 클래스 받았을 때 svg 이미지 컬러 화이트로 설정되도록 변경


### 요약
- 따로 서버 쪽은 작업하지 않고 프론트쪽 채팅방에 필요한 컴포넌트 구현하였고, 컴포넌트들을 조합해서 채팅방 페이지 구현했습니다.
- 일단은 mock 데이터로 테스트해보았습니다!
- 라우팅은 chatroom 으로 설정했습니다~
- 일단 핵심 기능을 구현할 수 있게만 View작업을 완료했고 추후에 전송 시간, 프로필 사진 추가할 예정입니다!


### 첨부
![Nov-28-2020 20-55-04](https://user-images.githubusercontent.com/52775389/100514974-410e4900-31bc-11eb-996e-414f1c3d9200.gif)


### 이슈
#72 