### PR TITLE
[CY] 클라이언트 드라이버 호출 (오더 생성) 기능 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,8 @@ import Home from '@routes/Home';
 import UserMain from '@routes/User/Main';
 import DriverMain from '@routes/Driver/Main';
 import Signup from '@routes/Signup';
+import SearchDriver from '@routes/SearchDriver';
+
 import theme from '@theme/.';
 import GlobalStyle from '@theme/global';
 import reducer from '@reducers/.';
@@ -31,6 +33,7 @@ const App: FC = () => (
             <Route exact path="/" component={auth(Home)} />
             <Route exact path="/user" component={auth(UserMain, 'user')} />
             <Route exact path="/driver" component={auth(DriverMain, 'driver')} />
+            <Route exact path="/user/searchDriver" component={auth(SearchDriver, 'user')} />
             <Route exact path="/signin" component={SignIn} />
             <Route exact path="/signup" component={Signup} />
             <Route exact path="/chatroom" component={auth(ChatRoom)} />

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export const CREATE_ORDER = gql`
+  mutation CreateOrder($startingPoint: LocationInfo!, $destination: LocationInfo!) {
+    createOrder(startingPoint: $startingPoint, destination: $destination) {
+      result
+      orderId
+      error
+    }
+  }
+`;

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,3 +1,5 @@
+import { OrderActions, ADD_ORDER_ID } from './order';
+
 interface Driver {
   licenseNumber: string;
   status: string;
@@ -9,14 +11,17 @@ export interface InitialState {
     name: string;
     driver?: Driver;
   };
+  orderId?: string;
 }
 
 const initialState: InitialState = {};
 
-type Action = { type: string };
+type Action = OrderActions;
 
 const reducer = (state: InitialState = initialState, action: Action): InitialState => {
   switch (action.type) {
+    case ADD_ORDER_ID:
+      return { ...state, orderId: action.orderId };
     default:
       return state;
   }

--- a/client/src/reducers/order.ts
+++ b/client/src/reducers/order.ts
@@ -1,0 +1,13 @@
+export const ADD_ORDER_ID = 'ADD_ORDER_ID';
+
+export interface AddOrderId {
+  type: typeof ADD_ORDER_ID;
+  orderId: string;
+}
+
+export const addOrderId = (orderId: string): AddOrderId => ({
+  type: ADD_ORDER_ID,
+  orderId,
+});
+
+export type OrderActions = AddOrderId;

--- a/client/src/routes/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/SearchDriver/SearchDriver.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react';
+import { Button, ActivityIndicator } from 'antd-mobile';
+
+import styled from '@theme/styled';
+import Header from '@components/HeaderWithMenu';
+
+const StyledSearchDriver = styled.div`
+  margin-bottom: 0.8rem;
+  height: 100%;
+
+  & > section {
+    position: relative;
+    height: calc(100% - 50px);
+    position: relative;
+    padding: 0 1.5rem 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+
+    & > .loading-center {
+      position: absolute;
+      left: 50%;
+      top: 40%;
+      transform: translateX(-50%);
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      font-weight: 700;
+
+      & > div {
+        margin-top: 1rem;
+      }
+    }
+
+    & > .am-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      height: 2rem;
+      margin-bottom: 0.8rem;
+      margin-top: 2rem;
+      font-weight: 700;
+      font-size: 0.9rem;
+    }
+  }
+`;
+
+const SearchDriver: FC = () => (
+  <StyledSearchDriver>
+    <Header className="green-header" />
+    <section>
+      <div className="loading-center">
+        주변에 운행이 가능한 드라이버를 탐색중입니다
+        <ActivityIndicator size="large" />
+      </div>
+      <Button type="warning">탐색 취소</Button>
+    </section>
+  </StyledSearchDriver>
+);
+
+export default SearchDriver;

--- a/client/src/routes/SearchDriver/index.ts
+++ b/client/src/routes/SearchDriver/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchDriver';

--- a/client/src/routes/User/Main/Main.tsx
+++ b/client/src/routes/User/Main/Main.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState, useCallback } from 'react';
 import { Toast, Button } from 'antd-mobile';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import AutoLocation from '@components/AutoLocation';
 import MapFrame from '@components/MapFrame';
@@ -8,6 +9,7 @@ import { Location } from '@components/GoogleMap';
 import { useCustomMutation } from '@hooks/useApollo';
 import { CREATE_ORDER } from '@queries/order.queries';
 import { CreateOrder } from '@/types/api';
+import { addOrderId } from '@reducers/order';
 
 import styled from '@theme/styled';
 
@@ -26,11 +28,13 @@ const StyledButton = styled(Button)`
 const TOAST_MESSAGE_DURATION = 2;
 
 const Main: FC = () => {
+  const dispatch = useDispatch();
   const history = useHistory();
   const [createOrderMutation] = useCustomMutation<CreateOrder>(CREATE_ORDER, {
     onCompleted: ({ createOrder }) => {
-      if (createOrder.result === 'success') {
+      if (createOrder.result === 'success' && createOrder.orderId) {
         history.push('/user/searchDriver');
+        dispatch(addOrderId(createOrder.orderId));
         return;
       }
       Toast.fail('라이더 탐색에 실패했습니다', TOAST_MESSAGE_DURATION);

--- a/server/src/api/shared/type.graphql
+++ b/server/src/api/shared/type.graphql
@@ -8,9 +8,9 @@ type Payment {
 }
 
 type Location {
-    coordinates: [Int]!
+    coordinates: [Float]!
 }
 
 input LocationInfo {
-  coordinates: [Int!]!
+  coordinates: [Float!]!
 }


### PR DESCRIPTION
### 작업 사항
- [x] 드라이버 탐색 페이지 구현
- [x] 드라이버 호출 기능 구현
- [x] 드라이버 호출 후 오더 생성 시 orderId 전역 스토어에 저장


### 요약
클라이언트 드라이버 호출 (오더 생성) 기능 구현 및 orderId 저장


### 첨부
![image](https://user-images.githubusercontent.com/49899406/100520579-d112b980-31e1-11eb-90b2-a618dc68959c.png)


### 이슈
#71 