### PR TITLE
[CY] 현재 배정되지 않은 오더 리스트 조회 API 구현

### DIFF
--- a/server/src/api/order/createOrder/createOrder.resolvers.ts
+++ b/server/src/api/order/createOrder/createOrder.resolvers.ts
@@ -7,7 +7,7 @@ const resolvers: Resolvers = {
       const { result, orderId, error } = await createOrder({
         startingPoint,
         destination,
-        user: req.user || '',
+        user: req.user?.id || '',
       });
 
       if (result === 'fail' || error) {

--- a/server/src/api/order/getUnassignedOrders/getUnassignedOrders.graphql
+++ b/server/src/api/order/getUnassignedOrders/getUnassignedOrders.graphql
@@ -1,0 +1,9 @@
+type GetUnassignedOrders {
+    result: String!
+    unassignedOrders: [Order!]
+    error: String
+}
+
+type Query {
+    getUnassignedOrders: GetUnassignedOrders! @auth
+}

--- a/server/src/api/order/getUnassignedOrders/getUnassingedOrders.resolvers.ts
+++ b/server/src/api/order/getUnassignedOrders/getUnassingedOrders.resolvers.ts
@@ -5,7 +5,7 @@ import getUnassignedOrders from '@services/order/getUnassingedOrders';
 const resolvers: Resolvers = {
   Query: {
     getUnassignedOrders: async (_, __, { req }) => {
-      const { result, unassignedOrders, error } = await getUnassignedOrders(req.user || '');
+      const { result, unassignedOrders, error } = await getUnassignedOrders(req.user?.id || '');
 
       if (!unassignedOrders && (result === 'fail' || error)) {
         return { result, error };

--- a/server/src/api/order/getUnassignedOrders/getUnassingedOrders.resolvers.ts
+++ b/server/src/api/order/getUnassignedOrders/getUnassingedOrders.resolvers.ts
@@ -1,0 +1,19 @@
+import { Resolvers } from '@type/api';
+
+import getUnassignedOrders from '@services/order/getUnassingedOrders';
+
+const resolvers: Resolvers = {
+  Query: {
+    getUnassignedOrders: async (_, __, { req }) => {
+      const { result, unassignedOrders, error } = await getUnassignedOrders(req.user || '');
+
+      if (!unassignedOrders && (result === 'fail' || error)) {
+        return { result, error };
+      }
+
+      return { result, unassignedOrders };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/shared/type.graphql
+++ b/server/src/api/shared/type.graphql
@@ -8,9 +8,9 @@ type Payment {
 }
 
 type Location {
-    coordinates: [Int]!
+    coordinates: [Float!]!
 }
 
 input LocationInfo {
-  coordinates: [Int!]!
+  coordinates: [Float!]!
 }

--- a/server/src/api/user/getUserInfo/getUserInfo.resolvers.ts
+++ b/server/src/api/user/getUserInfo/getUserInfo.resolvers.ts
@@ -5,7 +5,7 @@ import getUser from '@services/user/getUser';
 const resolvers: Resolvers = {
   Query: {
     getUserInfo: async (_, __, { req }) => {
-      const { user, error } = await getUser(req.user || '');
+      const { user, error } = await getUser(req.user?.id || '');
 
       if (error) {
         return { error };

--- a/server/src/models/order.ts
+++ b/server/src/models/order.ts
@@ -12,7 +12,7 @@ const orderSchema = new Schema({
   payment: { type: paymentSchema, required: false },
   startingPoint: { type: locationSchema, required: true },
   destination: { type: locationSchema, required: true },
-  status: { type: String, enum: ['close', 'active'], required: true },
+  status: { type: String, enum: ['close', 'active', 'waiting'], required: true },
   chat: [chatSchema],
   startedAt: Schema.Types.Date,
   completedAt: Schema.Types.Date,

--- a/server/src/passport/jwt.ts
+++ b/server/src/passport/jwt.ts
@@ -13,7 +13,7 @@ const JWTConfig = {
 
 const jwtVerify: VerifyCallback = async (jwtPayload, done) => {
   try {
-    const user = await User.findById(jwtPayload.id);
+    const user = await User.findById(jwtPayload.id, '_id type');
 
     if (user) return done(null, user);
     return done(null, false, { message: Message.InvalidToken });

--- a/server/src/services/order/createOrder.ts
+++ b/server/src/services/order/createOrder.ts
@@ -19,7 +19,7 @@ const createOrder = async ({ user, startingPoint, destination }: CreateOrderProp
       startingPoint,
       destination,
       payment: userPayment.get('payment'),
-      status: 'active',
+      status: 'waiting',
     });
     return { result: 'success', orderId: createdOrder.get('_id') };
   } catch (err) {

--- a/server/src/services/order/getUnassingedOrders.ts
+++ b/server/src/services/order/getUnassingedOrders.ts
@@ -9,7 +9,7 @@ const getUnassinedOrders = async (driverId: string) => {
   try {
     const driver = await User.findById(driverId, 'location');
     const centerPoint = driver?.get('location.coordinates') || [0, 0];
-    const unassignedOrders = ((await await await Order.find({
+    const unassignedOrders = ((await Order.find({
       status: 'waiting',
     })
       .where('startingPoint.coordinates')

--- a/server/src/services/order/getUnassingedOrders.ts
+++ b/server/src/services/order/getUnassingedOrders.ts
@@ -1,0 +1,29 @@
+import { Order as OrderType } from '@type/api';
+import Order from '@models/order';
+import User from '@models/user';
+
+const EARTH_RADIUS = 6378.1; // 지구 반지름
+const SEARCHING_KM = 10; // 검색 범위 (KM)
+
+const getUnassinedOrders = async (driverId: string) => {
+  try {
+    const driver = await User.findById(driverId, 'location');
+    const centerPoint = driver?.get('location.coordinates') || [0, 0];
+    const unassignedOrders = ((await await await Order.find({
+      status: 'waiting',
+    })
+      .where('startingPoint.coordinates')
+      .within()
+      .circle({
+        center: centerPoint,
+        radius: SEARCHING_KM / EARTH_RADIUS,
+        spherical: true,
+      })) as unknown) as OrderType[];
+
+    return { result: 'success', unassignedOrders };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default getUnassinedOrders;

--- a/server/src/types/request.ts
+++ b/server/src/types/request.ts
@@ -1,5 +1,8 @@
 import { Request } from 'express';
 
 export interface RequestWithUser extends Request {
-  user?: string;
+  user?: {
+    id: string;
+    type: string;
+  };
 }

--- a/server/src/util/isAuthenticated.ts
+++ b/server/src/util/isAuthenticated.ts
@@ -21,7 +21,11 @@ class IsAuthenticatedDirective extends SchemaDirectiveVisitor {
       await new Promise((resFn) => {
         passport.authenticate('jwt', (error, payload, { message } = {}) => {
           if (error || !payload) return res.status(401).send({ data: { result: 'fail', message } });
-          req.user = payload?.get('_id');
+          req.user = {
+            id: payload?.get('_id'),
+            type: payload?.get('type'),
+          };
+          console.log(req.user);
           resFn();
         })(req, res);
       });


### PR DESCRIPTION
### 작업 사항
- [x] 잘못 작성한 타입 조정 (위치정보 Int -> Float)
- [x] 오더 상태에 `'waiting'`추가 (상태만으로 배정되지 않은 오더 조회하려고 추가함)
- [x] 배정되지 않은 오더 조회 기능 구현
- [x] 배정되지 않은 오더 조회시 드라이버의 위치 반경 10KM에 출발지가 있어야만 조회하도록 구현


### 요약
배정되지 않은 오더리스트 조회, 드라이버 위치 반경 10KM에 출발지가 있어야 조회


### 이슈
#82 