### PR TITLE
[CY] 현재 배정되지 않은 오더 리스트 화면에 표시

### DIFF
--- a/client/src/components/AutoLocation/AutoLocation.tsx
+++ b/client/src/components/AutoLocation/AutoLocation.tsx
@@ -39,7 +39,7 @@ const AutoLocation: FC<Props> = ({ setPosition }) => {
     getGeocode({ address: description })
       .then((results) => getLatLng(results[0]))
       .then(({ lat, lng }) => {
-        setPosition({ lat, lng });
+        setPosition({ lat, lng, address: description });
       })
       .catch((error) => {
         console.log('Error: ', error);

--- a/client/src/components/GoogleMap/GoogleMap.tsx
+++ b/client/src/components/GoogleMap/GoogleMap.tsx
@@ -6,6 +6,7 @@ import getUserLocation from '@utils/getUserLocation';
 import Directions from './Directions';
 
 export interface Location {
+  address?: string;
   lat: number;
   lng: number;
 }

--- a/client/src/components/MapFrame/MapFrame.tsx
+++ b/client/src/components/MapFrame/MapFrame.tsx
@@ -19,14 +19,13 @@ const StyledMapFrame = styled.div`
   height: 100%;
 
   & > .map-section {
-    flex: 15 0 0;
     position: relative;
-    height: 100%;
+    height: 75%;
   }
 
   & > .control-section {
-    flex: 5 0 0;
     padding: 1.5rem;
+    height: 25%;
   }
 `;
 

--- a/client/src/components/OrderLog/OrderLog.tsx
+++ b/client/src/components/OrderLog/OrderLog.tsx
@@ -38,8 +38,8 @@ const StyledOrderLog = styled.div`
 const OrderLog: FC<Props> = ({ order, onClick }) => (
   <StyledOrderLog onClick={onClick}>
     <span className="order-dot" />
-    <span className="order-address">{`출발지: ${order.startingPoint}`}</span>
-    <span className="order-address">{`목적지: ${order.destination}`}</span>
+    <span className="order-address">{`출발지: ${order.startingPoint.address}`}</span>
+    <span className="order-address">{`목적지: ${order.destination.address}`}</span>
   </StyledOrderLog>
 );
 

--- a/client/src/components/OrderLog/OrderLog.tsx
+++ b/client/src/components/OrderLog/OrderLog.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react';
+
+import { GetUnassignedOrders_getUnassignedOrders_unassignedOrders as UnassignedOrder } from '@/types/api';
+import styled from '@theme/styled';
+
+interface Props {
+  order: UnassignedOrder;
+  onClick?: () => void;
+}
+
+const StyledOrderLog = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: ${({ theme }) => theme.LIGHT_GRAY};
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.4rem;
+  cursor: pointer;
+
+  & > .order-address {
+    width: 45%;
+    height: 0.8rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-weight: 700;
+    font-size: 0.8rem;
+  }
+
+  & > .order-dot {
+    background-color: ${({ theme }) => theme.PRIMARY};
+    width: 0.3rem;
+    height: 0.3rem;
+    border-radius: 0.15rem;
+  }
+`;
+
+const OrderLog: FC<Props> = ({ order, onClick }) => (
+  <StyledOrderLog onClick={onClick}>
+    <span className="order-dot" />
+    <span className="order-address">{`출발지: ${order.startingPoint}`}</span>
+    <span className="order-address">{`목적지: ${order.destination}`}</span>
+  </StyledOrderLog>
+);
+
+export default OrderLog;

--- a/client/src/components/OrderLog/index.ts
+++ b/client/src/components/OrderLog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderLog';

--- a/client/src/hooks/useApollo.ts
+++ b/client/src/hooks/useApollo.ts
@@ -18,8 +18,8 @@ import { RequestToken } from '@/types/api';
 
 const SUCCESS = 'success';
 
-interface QueryWrapper extends QueryResult<any, Record<string, any>> {
-  callQuery: (variables?: any) => Promise<ApolloQueryResult<any> | undefined>;
+interface QueryWrapper<T> extends QueryResult<T, Record<string, any>> {
+  callQuery: (variables?: any) => Promise<ApolloQueryResult<T> | undefined>;
 }
 
 const errorHandler = async (
@@ -38,10 +38,10 @@ const errorHandler = async (
   return undefined;
 };
 
-export const useCustomQuery = <T = any>(
+export const useCustomQuery = <T>(
   query: DocumentNode,
   options?: QueryHookOptions<T>,
-): QueryWrapper => {
+): QueryWrapper<T> => {
   const apolloClient = useApolloClient();
   const queryResult = useQuery<T>(query, {
     ...options,

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -17,9 +17,11 @@ export const GET_UNASSIGNED_ORDERS = gql`
       unassignedOrders {
         _id
         startingPoint {
+          address
           coordinates
         }
         destination {
+          address
           coordinates
         }
       }

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -9,3 +9,21 @@ export const CREATE_ORDER = gql`
     }
   }
 `;
+
+export const GET_UNASSIGNED_ORDERS = gql`
+  query GetUnassignedOrders {
+    getUnassignedOrders {
+      result
+      unassignedOrders {
+        _id
+        startingPoint {
+          coordinates
+        }
+        destination {
+          coordinates
+        }
+      }
+      error
+    }
+  }
+`;

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -1,9 +1,34 @@
+/* eslint-disable no-underscore-dangle */
 import React, { FC } from 'react';
+import { useCustomQuery } from '@hooks/useApollo';
 
+import styled from '@theme/styled';
 import MapFrame from '@components/MapFrame';
+import OrderLog from '@components/OrderLog';
+import { GET_UNASSIGNED_ORDERS } from '@queries/order.queries';
+import { GetUnassignedOrders } from '@/types/api';
+
+const StyledOrderLogList = styled.section`
+  height: 100%;
+  overflow: scroll;
+
+  & > div {
+    margin-bottom: 0.5rem;
+  }
+`;
 
 const Main: FC = () => {
-  return <MapFrame></MapFrame>;
+  const { data: orders } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
+
+  return (
+    <MapFrame>
+      <StyledOrderLogList>
+        {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
+          <OrderLog order={order} key={`order_list_${order._id}`} />
+        ))}
+      </StyledOrderLogList>
+    </MapFrame>
+  );
 };
 
 export default Main;

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -15,6 +15,16 @@ const StyledOrderLogList = styled.section`
   & > div {
     margin-bottom: 0.5rem;
   }
+
+  & > h1 {
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: ${({ theme }) => theme.BORDER};
+  }
 `;
 
 const Main: FC = () => {
@@ -24,8 +34,10 @@ const Main: FC = () => {
     <MapFrame>
       <StyledOrderLogList>
         {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
-          <OrderLog order={order} key={`order_list_${order._id}`} />
-        ))}
+          <>
+            <OrderLog order={order} key={`order_list_${order._id}`} />
+          </>
+        )) || <h1>현재 요청이 없습니다</h1>}
       </StyledOrderLogList>
     </MapFrame>
   );

--- a/client/src/routes/User/Main/Main.tsx
+++ b/client/src/routes/User/Main/Main.tsx
@@ -53,9 +53,11 @@ const Main: FC = () => {
     createOrderMutation({
       variables: {
         startingPoint: {
+          address: origin.address || '',
           coordinates: [origin.lat, origin.lng],
         },
         destination: {
+          address: destination.address || '',
           coordinates: [destination.lat, destination.lng],
         },
       },
@@ -72,7 +74,9 @@ const Main: FC = () => {
       <AutoLocation setPosition={setOrigin} />
       <AutoLocation setPosition={setDestination} />
       <EstimatedTime directions={directions} origin={origin} destination={destination} />
-      <StyledButton type="primary">라이더 탐색</StyledButton>
+      <StyledButton type="primary" onClick={onClickSearchDriver}>
+        라이더 탐색
+      </StyledButton>
     </MapFrame>
   );
 };

--- a/client/src/theme/index.ts
+++ b/client/src/theme/index.ts
@@ -3,6 +3,7 @@ export const theme = {
   BORDER: '#bfbfbf',
   FONT: '#2c2c2c',
   LIGHT: '#fff',
+  LIGHT_GRAY: '#eaeaea',
 };
 
 export type Theme = typeof theme;

--- a/server/src/api/shared/type.graphql
+++ b/server/src/api/shared/type.graphql
@@ -8,9 +8,11 @@ type Payment {
 }
 
 type Location {
+  address: String!
   coordinates: [Float!]!
 }
 
 input LocationInfo {
+  address: String!
   coordinates: [Float!]!
 }

--- a/server/src/models/location.ts
+++ b/server/src/models/location.ts
@@ -4,6 +4,12 @@ export interface Location {
   coordinates: number[];
 }
 
-const locationSchema = new Schema({ coordinates: [Number] }, { _id: false });
+const locationSchema = new Schema(
+  {
+    address: String,
+    coordinates: [Number],
+  },
+  { _id: false },
+);
 
 export default locationSchema;

--- a/server/src/util/isAuthenticated.ts
+++ b/server/src/util/isAuthenticated.ts
@@ -25,7 +25,6 @@ class IsAuthenticatedDirective extends SchemaDirectiveVisitor {
             id: payload?.get('_id'),
             type: payload?.get('type'),
           };
-          console.log(req.user);
           resFn();
         })(req, res);
       });


### PR DESCRIPTION
### 작업 사항
- [x] 오더 리스트에 표시할 OrderLog 컴포넌트 구현 
- [x] 배정되지 않은 오더리스트 데이터 조회 후 리스트로 페이지에 표시
- [x] 오더 리스트가 비어있을 때 화면에 메시지 출력
- [x] useApollo에 제네릭 타입 추가(좀더 명시적인 타입정의를 위해)
- [x] 오더 정보에 address속성 추가 (한글 주소 표시)


### 요약
배정되지 않은 오더 리스트 화면에 표시 (가까이 있는 출발지의 오더만 표시)


### 첨부
![image](https://user-images.githubusercontent.com/49899406/100542091-674eea00-328b-11eb-9dd3-55415b7f860f.png)


### 이슈
#82 