### PR TITLE
[JH] 모달 컴포넌트 구현

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,5 +6,6 @@
     <title>IKEYTAX</title>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -2,11 +2,12 @@ import React, { FC } from 'react';
 
 import { Icon } from 'antd-mobile';
 import styled from '@theme/styled';
+import Portal from '@utils/portal';
 
 interface Props {
   className?: string;
   visible?: boolean;
-  onClose?: any;
+  onClose?: () => void | undefined;
 }
 
 const ModalOverlay = styled.div<Props>`
@@ -56,7 +57,9 @@ const ModalInner = styled.div`
 
 const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
   const onMaskClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) onClose();
+    if (e.target === e.currentTarget && onClose) {
+      onClose();
+    }
   };
 
   const close = () => {
@@ -64,7 +67,7 @@ const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
   };
 
   return (
-    <>
+    <Portal elementId="modal-root">
       <ModalOverlay visible={visible}></ModalOverlay>
       <ModalWrapper className={className} tabIndex={-1} visible={visible} onClick={onMaskClick}>
         <ModalInner tabIndex={0} className="model-inner">
@@ -72,7 +75,7 @@ const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
           {children}
         </ModalInner>
       </ModalWrapper>
-    </>
+    </Portal>
   );
 };
 

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -1,0 +1,79 @@
+import React, { FC } from 'react';
+
+import { Icon } from 'antd-mobile';
+import styled from '@theme/styled';
+
+interface Props {
+  className?: string;
+  visible?: boolean;
+  onClose?: any;
+}
+
+const ModalOverlay = styled.div<Props>`
+  display: ${({ visible }) => (visible ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-color: ${({ theme }) => theme.MODAL_OVERLAY};
+  z-index: 999;
+`;
+
+const ModalWrapper = styled.div<Props>`
+  display: ${({ visible }) => (visible ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  overflow: auto;
+  outline: 0;
+`;
+
+const ModalInner = styled.div`
+  position: relative;
+  box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
+  color: ${({ theme }) => theme.LIGHT};
+  background-color: ${({ theme }) => theme.MODAL_BACKGROUND};
+  border-radius: 10px;
+  width: 80%;
+  height: 40%;
+  max-width: 400px;
+  max-height: 600px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin: 0 auto;
+  padding: 45px 20px;
+
+  & .close-button {
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+  }
+`;
+
+const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
+  const onMaskClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const close = () => {
+    if (onClose) onClose();
+  };
+
+  return (
+    <>
+      <ModalOverlay visible={visible}></ModalOverlay>
+      <ModalWrapper className={className} tabIndex={-1} visible={visible} onClick={onMaskClick}>
+        <ModalInner tabIndex={0} className="model-inner">
+          <Icon type="cross" className="close-button" onClick={close} />
+          {children}
+        </ModalInner>
+      </ModalWrapper>
+    </>
+  );
+};
+
+export default Modal;

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -55,7 +55,7 @@ const ModalInner = styled.div`
   }
 `;
 
-const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
+const Modal: FC<Props> = ({ visible = false, className, children, onClose }) => {
   const onMaskClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget && onClose) {
       onClose();

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -68,7 +68,7 @@ const Modal: FC<Props> = ({ visible, className, children, onClose }) => {
 
   return (
     <Portal elementId="modal-root">
-      <ModalOverlay visible={visible}></ModalOverlay>
+      <ModalOverlay visible={visible} />
       <ModalWrapper className={className} tabIndex={-1} visible={visible} onClick={onMaskClick}>
         <ModalInner tabIndex={0} className="model-inner">
           <Icon type="cross" className="close-button" onClick={close} />

--- a/client/src/components/Modal/index.ts
+++ b/client/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/client/src/hooks/useModal.ts
+++ b/client/src/hooks/useModal.ts
@@ -1,0 +1,17 @@
+import { useState, useCallback } from 'react';
+
+const useModal = (): [boolean, () => void, () => void] => {
+  const [isModal, setIsModal] = useState(false);
+
+  const openModal = useCallback(() => {
+    setIsModal(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsModal(false);
+  }, []);
+
+  return [isModal, openModal, closeModal];
+};
+
+export default useModal;

--- a/client/src/theme/index.ts
+++ b/client/src/theme/index.ts
@@ -3,6 +3,8 @@ export const theme = {
   BORDER: '#bfbfbf',
   FONT: '#2c2c2c',
   LIGHT: '#fff',
+  MODAL_BACKGROUND: 'rgba(90,153,115,0.75)',
+  MODAL_OVERLAY: 'rgba(0,0,0,0.3)',
 };
 
 export type Theme = typeof theme;

--- a/client/src/utils/portal.tsx
+++ b/client/src/utils/portal.tsx
@@ -1,0 +1,14 @@
+import { useMemo, FC } from 'react';
+import { createPortal } from 'react-dom';
+
+interface Props {
+  elementId: string;
+}
+
+const Portal: FC<Props> = ({ children, elementId }) => {
+  const rootElement = useMemo(() => document.getElementById(elementId), [elementId]) as HTMLElement;
+
+  return createPortal(children, rootElement);
+};
+
+export default Portal;


### PR DESCRIPTION
### 작업 사항
- [x] 오더 상세 표시 구현할 때 사용하기 위해 모달 컴포넌트 구현(다른 곳에도 재사용가능하도록)
- [x] useModal 커스텀훅 구현
- [x] modal 렌더링 최적화 (modal로 인해 다른 컴포넌트가 리렌더링 되지않도록) 


### 요약
- 재사용 가능하도록 modal 컴포넌트 구현해보았습니다.
- useModal과 함께 사용하시면 되고, useModal은 리턴 값으로 [isModal, openModal, closeModal] 을 리턴하는 IsModal은 모달의 오픈여부로 Modal 컴포넌트의 visible props에 전달해주시면 되고, openModal은 모달을 열고싶은 버튼에 onClick으로 넣어주시면 되고, closeModal은 Modal 컴포넌트에 onClose props에 전달해주시면 동작됩니다!

### 첨부
![Nov-29-2020 22-04-08](https://user-images.githubusercontent.com/52775389/100542683-eeea2800-328e-11eb-8354-d7a85494462f.gif)

### 이슈
#86 