### PR TITLE
[JH] order 클릭 시 상세정보 Modal 띄워주는 기능

### DIFF
--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -40,13 +40,13 @@ const ModalInner = styled.div`
   background-color: ${({ theme }) => theme.MODAL_BACKGROUND};
   border-radius: 10px;
   width: 80%;
-  height: 40%;
+  height: 35%;
   max-width: 400px;
   max-height: 600px;
   top: 50%;
   transform: translateY(-50%);
   margin: 0 auto;
-  padding: 45px 20px;
+  padding: 45px 25px;
 
   & .close-button {
     position: absolute;

--- a/client/src/components/OrderModalItem/OrderModalItem.tsx
+++ b/client/src/components/OrderModalItem/OrderModalItem.tsx
@@ -21,7 +21,9 @@ const StyledOrderItem = styled.div`
   & .origin,
   & .destination {
     display: block;
-    margin-bottom: 1rem;
+    margin-bottom: 0.8rem;
+    height: 1.2rem;
+    line-height: 1.2rem;
     text-align: left;
     overflow: hidden;
     white-space: nowrap;

--- a/client/src/components/OrderModalItem/OrderModalItem.tsx
+++ b/client/src/components/OrderModalItem/OrderModalItem.tsx
@@ -1,0 +1,56 @@
+import React, { FC } from 'react';
+
+import styled from '@theme/styled';
+import { Button } from 'antd-mobile';
+import { GetUnassignedOrders_getUnassignedOrders_unassignedOrders as UnassignedOrder } from '@/types/api';
+
+interface Props {
+  order: UnassignedOrder;
+  onClick?: () => void;
+}
+
+const StyledOrderItem = styled.div`
+  font-size: 1rem;
+  font-weight: 700;
+
+  & > div {
+    margin-bottom: 2rem;
+    text-align: center;
+  }
+
+  & .origin,
+  & .destination {
+    display: block;
+    margin-bottom: 1rem;
+    text-align: left;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  & .am-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.2rem;
+    font-size: 0.9rem;
+  }
+`;
+
+const OrderModalItem: FC<Props> = ({ order, onClick }) => {
+  return (
+    <StyledOrderItem>
+      <div>요청</div>
+      <div className="location-info">
+        <span className="origin">{`출발지: ${order.startingPoint.address}`}</span>
+        <span className="destination">{`목적지: ${order.destination.address}`}</span>
+      </div>
+      <div>해당 운행을 수락하시겠습니까?</div>
+      <Button type="primary" onClick={onClick}>
+        수락
+      </Button>
+    </StyledOrderItem>
+  );
+};
+
+export default OrderModalItem;

--- a/client/src/components/OrderModalItem/index.ts
+++ b/client/src/components/OrderModalItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderModalItem';

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable no-underscore-dangle */
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useCustomQuery } from '@hooks/useApollo';
 
 import styled from '@theme/styled';
 import MapFrame from '@components/MapFrame';
 import OrderLog from '@components/OrderLog';
+import Modal from '@components/Modal';
+import OrderModalItem from '@components/OrderModalItem';
 import { GET_UNASSIGNED_ORDERS } from '@queries/order.queries';
-import { GetUnassignedOrders } from '@/types/api';
+import useModal from '@hooks/useModal';
+import {
+  GetUnassignedOrders,
+  GetUnassignedOrders_getUnassignedOrders_unassignedOrders as Order,
+} from '@/types/api';
 
 const StyledOrderLogList = styled.section`
   height: 100%;
@@ -29,17 +35,31 @@ const StyledOrderLogList = styled.section`
 
 const Main: FC = () => {
   const { data: orders } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
+  const [isModal, openModal, closeModal] = useModal();
+  const [orderItem, setOrderItem] = useState<Order>();
+
+  const onClickOrder = (order: Order) => {
+    openModal();
+    setOrderItem(order);
+  };
 
   return (
-    <MapFrame>
-      <StyledOrderLogList>
-        {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
-          <>
-            <OrderLog order={order} key={`order_list_${order._id}`} />
-          </>
-        )) || <h1>현재 요청이 없습니다</h1>}
-      </StyledOrderLogList>
-    </MapFrame>
+    <>
+      <MapFrame>
+        <StyledOrderLogList>
+          {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
+            <OrderLog
+              order={order}
+              key={`order_list_${order._id}`}
+              onClick={() => onClickOrder(order)}
+            />
+          )) || <h1>현재 요청이 없습니다</h1>}
+        </StyledOrderLogList>
+      </MapFrame>
+      <Modal visible={isModal} onClose={closeModal}>
+        {orderItem && <OrderModalItem order={orderItem} />}
+      </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
### 작업 사항
- [x] order 클릭 시 해당 order의 상세정보 Modal로 띄워주는 기능 구현
- [x] 코드 스타일 수정 


### 요약
- orderItem을 상태 관리하여 해당 오더 클릭 시 orderItem의 상태를 클릭한 오더의 정보로 바꿔주고 Modal에 orderItem을 전달하도록 구현했습니다!


### 첨부
![Nov-30-2020 11-26-22](https://user-images.githubusercontent.com/52775389/100562380-e7fafe00-32fe-11eb-8506-02ce7690f7c4.gif)

### 이슈
#88 