### PR TITLE
[CY] 드라이버 오더 승인 API 구현

### DIFF
--- a/server/src/api/order/approvalOrder/approvalOrder.graphql
+++ b/server/src/api/order/approvalOrder/approvalOrder.graphql
@@ -1,0 +1,8 @@
+type ApprovalOrderResponse {
+    result: String!
+    error: String
+}
+
+type Mutation {
+    approvalOrder(orderId: String!): ApprovalOrderResponse! @auth
+}

--- a/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
+++ b/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
@@ -1,14 +1,18 @@
 import { Resolvers } from '@type/api';
 import approvalOrder from '@services/order/approvalOrder';
 
+export const APPROVAL_ORDER = 'APPROVAL_ORDER';
+
 const resolvers: Resolvers = {
   Mutation: {
-    approvalOrder: async (_, { orderId }, { req }) => {
+    approvalOrder: async (_, { orderId }, { req, pubsub }) => {
       const { result, error } = await approvalOrder(req.user?._id || '', orderId);
 
       if (result === 'fail' || error) {
         return { result, error };
       }
+
+      pubsub.publish(APPROVAL_ORDER, { subApprovalOrder: { approvalOrderId: orderId } });
 
       return { result };
     },

--- a/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
+++ b/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
@@ -1,0 +1,18 @@
+import { Resolvers } from '@type/api';
+import approvalOrder from '@services/order/approvalOrder';
+
+const resolvers: Resolvers = {
+  Mutation: {
+    approvalOrder: async (_, { orderId }, { req }) => {
+      const { result, error } = await approvalOrder(req.user?._id || '', orderId);
+
+      if (result === 'fail' || error) {
+        return { result, error };
+      }
+
+      return { result };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/order/subApprovalOrder/subApprovalOrder.graphql
+++ b/server/src/api/order/subApprovalOrder/subApprovalOrder.graphql
@@ -1,0 +1,7 @@
+type SubApprovalOrder {
+    approvalOrderId: String!
+}
+
+type Subscription {
+    subApprovalOrder(orderId: String, isDriver: Boolean): SubApprovalOrder!
+}

--- a/server/src/api/order/subApprovalOrder/subApprovalOrder.resolvers.ts
+++ b/server/src/api/order/subApprovalOrder/subApprovalOrder.resolvers.ts
@@ -1,0 +1,18 @@
+import { Resolvers } from '@type/api';
+import { withFilter } from 'apollo-server-express';
+
+import { APPROVAL_ORDER } from '@api/order/approvalOrder/approvalOrder.resolvers';
+
+const resolvers: Resolvers = {
+  Subscription: {
+    subApprovalOrder: {
+      subscribe: withFilter(
+        (_, __, { pubsub }) => pubsub.asyncIterator(APPROVAL_ORDER),
+        (payload, variables) =>
+          payload.subApprovalOrder.approvalOrderId === variables.orderId || variables.isDriver,
+      ),
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -19,6 +19,7 @@ export default () => {
         useNewUrlParser: true,
         useUnifiedTopology: true,
         useCreateIndex: true,
+        useFindAndModify: false,
         dbName: DB_NAME,
       })
       .then(() => console.log(message.CONNECT_SUCCEED))

--- a/server/src/services/order/approvalOrder.ts
+++ b/server/src/services/order/approvalOrder.ts
@@ -1,0 +1,13 @@
+import Order from '@models/order';
+
+const approvalOrder = async (driverId: string, orderId: string) => {
+  try {
+    await Order.findByIdAndUpdate(orderId, { driver: driverId });
+
+    return { result: 'success' };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default approvalOrder;

--- a/server/src/services/order/approvalOrder.ts
+++ b/server/src/services/order/approvalOrder.ts
@@ -2,7 +2,7 @@ import Order from '@models/order';
 
 const approvalOrder = async (driverId: string, orderId: string) => {
   try {
-    await Order.findByIdAndUpdate(orderId, { driver: driverId });
+    await Order.findByIdAndUpdate(orderId, { driver: driverId, status: 'active' });
 
     return { result: 'success' };
   } catch (err) {


### PR DESCRIPTION
### 작업 사항
- [x] 드라이버 오더 승인 API 구현
- [x] 드라이버 오더 승인 구독 API 구현 (subscription)
  - 구독할 때 인자를 `orderId`와 `isDriver`를 받음
  - `orderId`는 구독 시 해당 오더 아이디를 보낸 유저만 오더 승인 여부를 알 수 있도록 설정
  - `isDriver`는 구독 시 드라이버는 자신의 로컬 오더 목록에서 승인된 오더를 지워야 하기 때문에 모든 드라이버는 승인된 오더 정보를 구독
  - 만약 좀 더 좋은 방법이 있다면 코멘트 달아주시면 굳굳!


### 알림
- 작업하다가 subscription에 `@auth` direction이 적용되지 않는 문제 발견 #95
- 일단 subscription에 `@auth`를 적용하지 않고 기능 개발함


### 요약
드라이버 오더 승인 및 승인 구독 API 구현, 버그 발견.... (😢)


### 이슈
#91 