### PR TITLE
[JE] 드라이버 출발지까지 실시간 이동경로 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import SignIn from '@/routes/SignIn';
 import Home from '@routes/Home';
 import UserMain from '@routes/User/Main';
 import DriverMain from '@routes/Driver/Main';
+import DriverGoToOrigin from '@routes/Driver/GoToOrigin';
 import Signup from '@routes/Signup';
 import SearchDriver from '@routes/SearchDriver';
 
@@ -33,6 +34,7 @@ const App: FC = () => (
             <Route exact path="/" component={auth(Home)} />
             <Route exact path="/user" component={auth(UserMain, 'user')} />
             <Route exact path="/driver" component={auth(DriverMain, 'driver')} />
+            <Route exact path="/driver/goToOrigin" component={auth(DriverGoToOrigin, 'driver')} />
             <Route exact path="/user/searchDriver" component={auth(SearchDriver, 'user')} />
             <Route exact path="/signin" component={SignIn} />
             <Route exact path="/signup" component={Signup} />

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -10,6 +10,26 @@ export const CREATE_ORDER = gql`
   }
 `;
 
+export const GET_ORDER = gql`
+  query GetOrderInfo($orderId: String!) {
+    getOrderInfo(orderId: $orderId) {
+      result
+      order {
+        _id
+        startingPoint {
+          address
+          coordinates
+        }
+        destination {
+          address
+          coordinates
+        }
+      }
+      error
+    }
+  }
+`;
+
 export const GET_UNASSIGNED_ORDERS = gql`
   query GetUnassignedOrders {
     getUnassignedOrders {

--- a/client/src/queries/user.queries.ts
+++ b/client/src/queries/user.queries.ts
@@ -50,3 +50,11 @@ export const SIGNUP_DRIVER = gql`
     }
   }
 `;
+
+export const UPDATE_DRIVER_LOCATION = gql`
+  mutation UpdateDriverLocation($lat: Float!, $lng: Float!) {
+    updateDriverLocation(lat: $lat, lng: $lng) {
+      result
+    }
+  }
+`;

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -7,6 +7,7 @@ import { GET_ORDER } from '@queries/order.queries';
 import { UPDATE_DRIVER_LOCATION } from '@queries/user.queries';
 import { GetOrderInfo, UpdateDriverLocation } from '@/types/api';
 import { Location } from '@components/GoogleMap/GoogleMap';
+import getUserLocation from '@utils/getUserLocation';
 import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 
 const StyledDriverGoToOriginMenu = styled.section`
@@ -48,16 +49,14 @@ const GoToOrigin = () => {
   const order = data?.getOrderInfo.order;
 
   const updateCurrentLocation = async () => {
-    const currLocation = await new Promise<Location>((res) => {
-      window.navigator.geolocation.getCurrentPosition((position) => {
-        res({ lat: position.coords.latitude, lng: position.coords.longitude });
-      });
-    });
+    const currLocation = await getUserLocation();
 
-    setCurrentLocation(currLocation);
-    updateDriverLocationMutation({
-      variables: { lat: currLocation.lat, lng: currLocation.lng },
-    });
+    if (currLocation) {
+      setCurrentLocation(currLocation);
+      updateDriverLocationMutation({
+        variables: { lat: currLocation.lat, lng: currLocation.lng },
+      });
+    }
   };
 
   useEffect(() => {

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -4,9 +4,10 @@ import styled from '@theme/styled';
 
 import MapFrame from '@components/MapFrame';
 import { GET_ORDER } from '@queries/order.queries';
-import { GetOrderInfo } from '@/types/api';
+import { UPDATE_DRIVER_LOCATION } from '@queries/user.queries';
+import { GetOrderInfo, UpdateDriverLocation } from '@/types/api';
 import { Location } from '@components/GoogleMap/GoogleMap';
-import { useCustomQuery } from '@hooks/useApollo';
+import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 
 const StyledDriverGoToOriginMenu = styled.section`
   height: 100%;
@@ -40,6 +41,9 @@ const GoToOrigin = () => {
   const { data } = useCustomQuery<GetOrderInfo>(GET_ORDER, {
     variables: { orderId: '5fc45539e439ea40e869bf47' },
   });
+  const [updateDriverLocationMutation] = useCustomMutation<UpdateDriverLocation>(
+    UPDATE_DRIVER_LOCATION,
+  );
 
   const order = data?.getOrderInfo.order;
 
@@ -49,7 +53,11 @@ const GoToOrigin = () => {
         res({ lat: position.coords.latitude, lng: position.coords.longitude });
       });
     });
+
     setCurrentLocation(currLocation);
+    updateDriverLocationMutation({
+      variables: { lat: currLocation.lat, lng: currLocation.lng },
+    });
   };
 
   useEffect(() => {

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from 'antd-mobile';
+import styled from '@theme/styled';
+
+import MapFrame from '@components/MapFrame';
+import { GET_ORDER } from '@queries/order.queries';
+import { GetOrderInfo } from '@/types/api';
+import { Location } from '@components/GoogleMap/GoogleMap';
+import { useCustomQuery } from '@hooks/useApollo';
+
+const StyledDriverGoToOriginMenu = styled.section`
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+
+  & > .driver-start-order-btn {
+    width: 100%;
+    & > .driver-start-order-info {
+      display: flex;
+      justify-content: center;
+      color: grey;
+    }
+
+    & > .am-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      height: 2rem;
+      margin: 0.8rem 0;
+      font-weight: 700;
+      font-size: 0.9rem;
+    }
+  }
+`;
+
+const GoToOrigin = () => {
+  const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
+  const [currentLocation, setCurrentLocation] = useState({ lat: 0, lng: 0 });
+  const { data } = useCustomQuery<GetOrderInfo>(GET_ORDER, {
+    variables: { orderId: '5fc45539e439ea40e869bf47' },
+  });
+
+  const order = data?.getOrderInfo.order;
+
+  const updateCurrentLocation = async () => {
+    const currLocation = await new Promise<Location>((res) => {
+      window.navigator.geolocation.getCurrentPosition((position) => {
+        res({ lat: position.coords.latitude, lng: position.coords.longitude });
+      });
+    });
+    setCurrentLocation(currLocation);
+  };
+
+  useEffect(() => {
+    const updateCurrentLocationInterval = setInterval(updateCurrentLocation, 5000);
+
+    return () => {
+      clearInterval();
+    };
+  }, []);
+
+  return (
+    <>
+      <MapFrame
+        origin={currentLocation}
+        destination={{
+          lat: order?.startingPoint.coordinates[0] as number,
+          lng: order?.startingPoint.coordinates[1] as number,
+        }}
+        setDirections={setDirections}
+        directions={directions}
+      >
+        <StyledDriverGoToOriginMenu>
+          <div className="driver-start-order-btn">
+            <div className="driver-start-order-info">손님이 탑승하시고 나서 눌러주세요.</div>
+            <Button type="primary">운행시작</Button>
+          </div>
+        </StyledDriverGoToOriginMenu>
+      </MapFrame>
+    </>
+  );
+};
+
+export default GoToOrigin;

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -64,7 +64,7 @@ const GoToOrigin = () => {
     const updateCurrentLocationInterval = setInterval(updateCurrentLocation, 5000);
 
     return () => {
-      clearInterval();
+      clearInterval(updateCurrentLocationInterval);
     };
   }, []);
 

--- a/client/src/routes/Driver/GoToOrigin/index.ts
+++ b/client/src/routes/Driver/GoToOrigin/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GoToOrigin';

--- a/server/src/api/user/subLocation/subLocation.graphql
+++ b/server/src/api/user/subLocation/subLocation.graphql
@@ -4,5 +4,5 @@ type LocationWithOrderId {
 }
 
 type Subscription {
-    subLocation(orderId: String!): LocationWithOrderId! @auth
+    subLocation(orderId: String!): LocationWithOrderId!
 }

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.graphql
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.graphql
@@ -4,6 +4,6 @@ type UpdateLocationResponse {
 }
 
 type Mutation {
-    updateDriverLocation(curLocation: LocationInfo!): UpdateLocationResponse! @auth
+    updateDriverLocation(lat: Float!, lng: Float!): UpdateLocationResponse! @auth
 }
 

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -1,23 +1,19 @@
 import { Resolvers } from '@type/api';
 import updateDriverLocation from '@services/user/updateDriverLocation';
-import Order from '@models/order';
 
 export const UPDATE_DRIVER_LOCATION = 'UPDATE_DRIVER_LOCATION';
 
 const resolvers: Resolvers = {
   Mutation: {
     updateDriverLocation: async (_, { lat, lng }, { req, pubsub }) => {
-      const { result, error } = await updateDriverLocation({
+      const { result, orderId, error } = await updateDriverLocation({
         userId: req.user?._id,
         userType: req.user?.type,
         curLocation: { coordinates: [lat, lng] },
       });
-      const order = await Order.findOne({ driver: req.user?._id, status: 'activate' });
-      if (order) {
-        pubsub.publish(UPDATE_DRIVER_LOCATION, {
-          subLocation: { coordinates: [lat, lng], orderId: order._id },
-        });
-      }
+      pubsub.publish(UPDATE_DRIVER_LOCATION, {
+        subLocation: { coordinates: [lat, lng], orderId },
+      });
 
       if (result === 'fail') {
         return { result, error };

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -6,16 +6,16 @@ export const UPDATE_DRIVER_LOCATION = 'UPDATE_DRIVER_LOCATION';
 
 const resolvers: Resolvers = {
   Mutation: {
-    updateDriverLocation: async (_, { curLocation }, { req, pubsub }) => {
+    updateDriverLocation: async (_, { lat, lng }, { req, pubsub }) => {
       const { result, error } = await updateDriverLocation({
         userId: req.user?._id,
         userType: req.user?.type,
-        curLocation,
+        curLocation: { coordinates: [lat, lng] },
       });
-      const order = await Order.findOne({ user: req.user?._id, status: 'waiting' });
+      const order = await Order.findOne({ driver: req.user?._id, status: 'activate' });
       if (order) {
         pubsub.publish(UPDATE_DRIVER_LOCATION, {
-          subLocation: { ...curLocation, orderId: order._id },
+          subLocation: { coordinates: [lat, lng], orderId: order._id },
         });
       }
 

--- a/server/src/services/user/updateDriverLocation.ts
+++ b/server/src/services/user/updateDriverLocation.ts
@@ -16,7 +16,7 @@ const updateDriverLocation = async ({ userId, userType, curLocation }: UpdateLoc
     await User.updateOne(
       { _id: userId },
       {
-        location: curLocation,
+        location: { coordinates: curLocation.coordinates },
       },
     );
     return { result: 'success' };

--- a/server/src/services/user/updateDriverLocation.ts
+++ b/server/src/services/user/updateDriverLocation.ts
@@ -1,5 +1,6 @@
 import User, { LoginType, loginType } from '@models/user';
 import { Location } from '@models/location';
+import Order from '@models/order';
 import { Message } from '@util/server-message';
 
 interface UpdateLocationProps {
@@ -19,7 +20,10 @@ const updateDriverLocation = async ({ userId, userType, curLocation }: UpdateLoc
         location: { coordinates: curLocation.coordinates },
       },
     );
-    return { result: 'success' };
+
+    const order = await Order.findOne({ driver: userId, status: 'activate' });
+
+    return { result: 'success', orderId: order?._id };
   } catch (err) {
     return { result: 'fail', error: err.message };
   }


### PR DESCRIPTION
### 작업 사항
- [x] 오더 정보 조회 API 작성
- [x] 드라이버가 출발지까지 이동하는 경로를 실시간으로 보여주는 페이지 구현
- [x] 드라이버의 위치가 수정될 때마다 서버에 업데이트

### 요약
드라이버의 출발지까지의 이동을 실시간으로 보여주는 페이지를 구현했습니다.
테스트 하기 쉽도록 드라이버 위치 확인 시간을 5초로 지정했습니다. 
현재 페이지의 A마크는 드라이브의 현재 위치를, B마크는 출발지를 의미합니다.

### 첨부
![image](https://user-images.githubusercontent.com/43084680/100617090-5b335d00-335d-11eb-8eca-1b955ebc7201.png)



### 이슈
#84 