### PR TITLE
[CY] 오더 승인 시 정보에서 차량정보 표시

### DIFF
--- a/client/src/components/CarInfo/CarInfo.tsx
+++ b/client/src/components/CarInfo/CarInfo.tsx
@@ -1,10 +1,11 @@
 import React, { FC } from 'react';
-import { Message } from '@utils/client-message';
 import { CarInfo as CarInfoType } from '@/types/api';
 import styled from '@/theme/styled';
+import carTypeMapper from './carTypeMapper';
 
 interface Props {
   carInfo?: CarInfoType;
+  title?: string;
 }
 
 const StyledCarInfo = styled.div`
@@ -12,7 +13,7 @@ const StyledCarInfo = styled.div`
   flex-direction: column;
   justify-content: center;
   height: 100%;
-  padding: 1rem 2rem;
+  padding: 1rem;
 
   & > h1 {
     text-align: center;
@@ -27,14 +28,18 @@ const StyledCarInfo = styled.div`
   }
 `;
 
-const CarInfo: FC<Props> = ({ carInfo }) => {
+const CarInfo: FC<Props> = ({ carInfo, title }) => {
   return (
     <StyledCarInfo>
-      <h1>{Message.DriverAjacent}</h1>
+      <h1>{title}</h1>
       <span>차량번호 : {carInfo?.carNumber}</span>
-      <span>차량타입: {carInfo?.carType}</span>
+      <span>차량타입: {carTypeMapper(carInfo?.carType)}</span>
     </StyledCarInfo>
   );
+};
+
+CarInfo.defaultProps = {
+  title: '',
 };
 
 export default CarInfo;

--- a/client/src/components/CarInfo/carTypeMapper.ts
+++ b/client/src/components/CarInfo/carTypeMapper.ts
@@ -1,0 +1,14 @@
+const carTypeMapper = (carType?: string): string => {
+  switch (carType) {
+    case 'large':
+      return '대형';
+    case 'middle':
+      return '중형';
+    case 'small':
+      return '소형';
+    default:
+      return '정보 없음';
+  }
+};
+
+export default carTypeMapper;

--- a/client/src/hooks/useApollo.ts
+++ b/client/src/hooks/useApollo.ts
@@ -19,7 +19,7 @@ import { RequestToken } from '@/types/api';
 const SUCCESS = 'success';
 
 interface QueryWrapper<T> extends QueryResult<T, Record<string, any>> {
-  callQuery: (variables?: any) => Promise<ApolloQueryResult<T> | undefined>;
+  callQuery: (variables?: any) => Promise<ApolloQueryResult<T>>;
 }
 
 const errorHandler = async (

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -46,3 +46,16 @@ export const SUB_APPROVAL_ORDER = gql`
     }
   }
 `;
+
+export const GET_ORDER_CAR_INFO = gql`
+  query GetOrderCarInfo($orderId: String!) {
+    getOrderCarInfo(orderId: $orderId) {
+      result
+      error
+      carInfo {
+        carNumber
+        carType
+      }
+    }
+  }
+`;

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,4 +1,5 @@
-import { OrderActions, ADD_ORDER_ID } from './order';
+import { CarInfo } from '@/types/api';
+import { OrderActions, ADD_ORDER_ID, ADD_CAR_INFO } from './order';
 
 interface Driver {
   licenseNumber: string;
@@ -13,6 +14,7 @@ export interface InitialState {
   };
   order?: {
     id?: string;
+    carInfo?: CarInfo;
   };
 }
 
@@ -24,6 +26,8 @@ const reducer = (state: InitialState = initialState, action: Action): InitialSta
   switch (action.type) {
     case ADD_ORDER_ID:
       return { ...state, order: { ...state.order, id: action.orderId } };
+    case ADD_CAR_INFO:
+      return { ...state, order: { ...state.order, carInfo: action.carInfo } };
     default:
       return state;
   }

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -11,7 +11,9 @@ export interface InitialState {
     name: string;
     driver?: Driver;
   };
-  orderId?: string;
+  order?: {
+    id?: string;
+  };
 }
 
 const initialState: InitialState = {};
@@ -21,7 +23,7 @@ type Action = OrderActions;
 const reducer = (state: InitialState = initialState, action: Action): InitialState => {
   switch (action.type) {
     case ADD_ORDER_ID:
-      return { ...state, orderId: action.orderId };
+      return { ...state, order: { ...state.order, id: action.orderId } };
     default:
       return state;
   }

--- a/client/src/reducers/order.ts
+++ b/client/src/reducers/order.ts
@@ -1,5 +1,9 @@
-export const ADD_ORDER_ID = 'ADD_ORDER_ID';
+import { CarInfo } from '@/types/api';
 
+export const ADD_ORDER_ID = 'ADD_ORDER_ID';
+export const ADD_CAR_INFO = 'ADD_CAR_INFO';
+
+// addOrderID
 export interface AddOrderId {
   type: typeof ADD_ORDER_ID;
   orderId: string;
@@ -10,4 +14,15 @@ export const addOrderId = (orderId: string): AddOrderId => ({
   orderId,
 });
 
-export type OrderActions = AddOrderId;
+// addCarInfo
+export interface AddCarInfo {
+  type: typeof ADD_CAR_INFO;
+  carInfo: CarInfo;
+}
+
+export const addCarInfo = (carInfo: CarInfo): AddCarInfo => ({
+  type: ADD_CAR_INFO,
+  carInfo,
+});
+
+export type OrderActions = AddOrderId | AddCarInfo;

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -37,6 +37,7 @@ const Main: FC = () => {
   const { data: orders } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
   const [isModal, openModal, closeModal] = useModal();
   const [orderItem, setOrderItem] = useState<Order>();
+  const { unassignedOrders } = orders?.getUnassignedOrders || {};
 
   const onClickOrder = (order: Order) => {
     openModal();
@@ -47,13 +48,17 @@ const Main: FC = () => {
     <>
       <MapFrame>
         <StyledOrderLogList>
-          {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
-            <OrderLog
-              order={order}
-              key={`order_list_${order._id}`}
-              onClick={() => onClickOrder(order)}
-            />
-          )).length || <h1>현재 요청이 없습니다</h1>}
+          {unassignedOrders && unassignedOrders?.length !== 0 ? (
+            unassignedOrders?.map((order) => (
+              <OrderLog
+                order={order}
+                key={`order_list_${order._id}`}
+                onClick={() => onClickOrder(order)}
+              />
+            ))
+          ) : (
+            <h1>현재 요청이 없습니다</h1>
+          )}
         </StyledOrderLogList>
       </MapFrame>
       <Modal visible={isModal} onClose={closeModal}>

--- a/client/src/routes/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/SearchDriver/SearchDriver.tsx
@@ -63,7 +63,7 @@ const SearchDriver: FC = () => {
   const history = useHistory();
   const dispatch = useDispatch();
   const [isModal, onOpenModal, onCloseModal] = useModal();
-  const { refetch } = useCustomQuery<GetOrderCarInfo>(GET_ORDER_CAR_INFO, {
+  const { callQuery } = useCustomQuery<GetOrderCarInfo>(GET_ORDER_CAR_INFO, {
     skip: true,
   });
   const { id: orderId } = useSelector((state: InitialState) => state.order || {});
@@ -78,7 +78,7 @@ const SearchDriver: FC = () => {
   }, []);
 
   const onOpenOrderModal = useCallback(async () => {
-    const { data } = await refetch({ orderId });
+    const { data } = await callQuery({ orderId });
     const { carInfo: carInfoData } = data.getOrderCarInfo;
     if (!carInfoData) {
       return;

--- a/client/src/routes/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/SearchDriver/SearchDriver.tsx
@@ -58,7 +58,7 @@ const StyledSearchDriver = styled.div`
 const SearchDriver: FC = () => {
   const history = useHistory();
   const [isModal, onOpenModal, onCloseModal] = useModal();
-  const { orderId } = useSelector((state: InitialState) => state);
+  const { id: orderId } = useSelector((state: InitialState) => state.order || {});
   const { data: approvalOrder } = useSubscription<SubApprovalOrder>(SUB_APPROVAL_ORDER, {
     variables: { orderId },
   });

--- a/client/src/routes/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/SearchDriver/SearchDriver.tsx
@@ -1,16 +1,20 @@
 import React, { FC, useCallback, useEffect } from 'react';
 import { Button, ActivityIndicator } from 'antd-mobile';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useSubscription } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
 
 import styled from '@theme/styled';
 import Header from '@components/HeaderWithMenu';
 import Modal from '@components/Modal';
+import CarInfo from '@components/CarInfo';
 import { InitialState } from '@reducers/.';
-import { SUB_APPROVAL_ORDER } from '@queries/order.queries';
-import { SubApprovalOrder } from '@/types/api';
+import { SUB_APPROVAL_ORDER, GET_ORDER_CAR_INFO } from '@queries/order.queries';
+import { SubApprovalOrder, GetOrderCarInfo } from '@/types/api';
+import { useCustomQuery } from '@hooks/useApollo';
 import useModal from '@hooks/useModal';
+import { addCarInfo } from '@reducers/order';
+import { Message } from '@utils/client-message';
 
 const StyledSearchDriver = styled.div`
   margin-bottom: 0.8rem;
@@ -57,8 +61,13 @@ const StyledSearchDriver = styled.div`
 
 const SearchDriver: FC = () => {
   const history = useHistory();
+  const dispatch = useDispatch();
   const [isModal, onOpenModal, onCloseModal] = useModal();
+  const { refetch } = useCustomQuery<GetOrderCarInfo>(GET_ORDER_CAR_INFO, {
+    skip: true,
+  });
   const { id: orderId } = useSelector((state: InitialState) => state.order || {});
+  const { carInfo } = useSelector((state: InitialState) => state.order || {});
   const { data: approvalOrder } = useSubscription<SubApprovalOrder>(SUB_APPROVAL_ORDER, {
     variables: { orderId },
   });
@@ -68,9 +77,19 @@ const SearchDriver: FC = () => {
     history.push('/user/waiting');
   }, []);
 
+  const onOpenOrderModal = useCallback(async () => {
+    const { data } = await refetch({ orderId });
+    const { carInfo: carInfoData } = data.getOrderCarInfo;
+    if (!carInfoData) {
+      return;
+    }
+    dispatch(addCarInfo(carInfoData));
+    onOpenModal();
+  }, [orderId]);
+
   useEffect(() => {
     if (orderId && approvalOrder && orderId === approvalOrder?.subApprovalOrder.approvalOrderId) {
-      onOpenModal();
+      onOpenOrderModal();
     }
   }, [orderId, approvalOrder]);
 
@@ -81,13 +100,13 @@ const SearchDriver: FC = () => {
         <section>
           <div className="loading-center">
             주변에 운행이 가능한 드라이버를 탐색중입니다
-            <ActivityIndicator size="large" />
+            {!isModal && <ActivityIndicator size="large" />}
           </div>
           <Button type="warning">탐색 취소</Button>
         </section>
       </StyledSearchDriver>
       <Modal visible={isModal} onClose={onClickModalCloseHandler}>
-        오더가 매칭되었습니다.
+        {carInfo && <CarInfo carInfo={carInfo} title={Message.DriverMatchingCompolete} />}
       </Modal>
     </>
   );

--- a/client/src/utils/client-message.ts
+++ b/client/src/utils/client-message.ts
@@ -9,4 +9,5 @@ export const Message = {
   CarNumberGuidance: '입력이 올바르지 않습니다. 예시: 12가 1234',
   ExpiryDateGuidance: '예시: MM/YY',
   DriverAjacent: '차량이 곧 도착합니다.',
+  DriverMatchingCompolete: '차량이 매칭되었습니다',
 };

--- a/server/src/api/order/getOrderCarInfo/getOrderCarInfo.graphql
+++ b/server/src/api/order/getOrderCarInfo/getOrderCarInfo.graphql
@@ -1,0 +1,9 @@
+type GetOrderCarInfoResponse {
+  result: String!
+  carInfo: Car
+  error: String
+}
+
+type Query {
+  getOrderCarInfo(orderId: String!): GetOrderCarInfoResponse! @auth
+}

--- a/server/src/api/order/getOrderCarInfo/getOrderCarInfo.resolvers.ts
+++ b/server/src/api/order/getOrderCarInfo/getOrderCarInfo.resolvers.ts
@@ -1,0 +1,19 @@
+import { Resolvers } from '@type/api';
+
+import getOrderCarInfo from '@services/order/getOrderCarInfo';
+
+const resolvers: Resolvers = {
+  Query: {
+    getOrderCarInfo: async (_, { orderId }, { req }) => {
+      const { result, carInfo, error } = await getOrderCarInfo(req.user?._id || '', orderId);
+
+      if (result === 'fail' || error) {
+        return { result, error };
+      }
+
+      return { result, carInfo };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/models/order.ts
+++ b/server/src/models/order.ts
@@ -7,7 +7,7 @@ import chatSchema from './chat';
 const orderSchema = new Schema({
   id: Schema.Types.ObjectId,
   user: { type: Schema.Types.ObjectId, required: true },
-  driver: Schema.Types.ObjectId,
+  driver: { type: Schema.Types.ObjectId, ref: 'User' },
   amount: Number,
   payment: { type: paymentSchema, required: false },
   startingPoint: { type: locationSchema, required: true },

--- a/server/src/services/order/getOrderCarInfo.ts
+++ b/server/src/services/order/getOrderCarInfo.ts
@@ -1,0 +1,18 @@
+import Order from '@models/order';
+
+const getOrderCarInfo = async (userId: string, orderId: string) => {
+  try {
+    const order = await Order.findOne({ _id: orderId, user: userId }, 'driver').populate('driver');
+    const carInfo = order?.get('driver.driver.car');
+
+    if (!carInfo) {
+      return { result: 'fail' };
+    }
+
+    return { result: 'success', carInfo };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default getOrderCarInfo;


### PR DESCRIPTION
### 작업 사항
- [x] 오더 정보에서 차량정보 조회 API 구현
- [x] 오더 정보에서 차량정보 표시
- [x] 차량정보 redux store에 저장
- [x] 오더 리스트 버그 수정 (리스트가 있을 경우 컴포넌트가 아닌 숫자가 표시됨)

#### 추가
- 작은 해상도에서 레이아웃 깨짐이 약간 발생해 모달 레이아웃을 약간 수정했슴니다 :)


### 요약
오더 승인 시 모달에서 차량정보 표시


### 첨부
![capture](https://user-images.githubusercontent.com/49899406/100615327-cb8caf00-335a-11eb-920a-982b72943a31.gif)

### 이슈
#103 