### PR TITLE
[JH] 오더 수락 시 오더 리스트 업데이트 기능 구현

### DIFF
--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -50,18 +50,6 @@ export const SUB_APPROVAL_ORDER = gql`
 export const UPDATE_ORDER_LIST = gql`
   subscription UpdateOrderList {
     updateOrderList {
-      error
-      unassignedOrders {
-        _id
-        startingPoint {
-          address
-          coordinates
-        }
-        destination {
-          address
-          coordinates
-        }
-      }
       result
     }
   }

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -46,3 +46,23 @@ export const SUB_APPROVAL_ORDER = gql`
     }
   }
 `;
+
+export const UPDATE_ORDER_LIST = gql`
+  subscription UpdateOrderList {
+    updateOrderList {
+      error
+      unassignedOrders {
+        _id
+        startingPoint {
+          address
+          coordinates
+        }
+        destination {
+          address
+          coordinates
+        }
+      }
+      result
+    }
+  }
+`;

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -35,18 +35,15 @@ const StyledOrderLogList = styled.section`
 `;
 
 const Main: FC = () => {
-  const { data: orders } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
+  const { data: orders, callQuery } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
   const { unassignedOrders } = orders?.getUnassignedOrders || {};
   const [orderData, setOrderData] = useState<Order[] | null | undefined>();
   const [isModal, openModal, closeModal] = useModal();
   const [orderItem, setOrderItem] = useState<Order>();
   const { data } = useSubscription(UPDATE_ORDER_LIST, {
-    onSubscriptionData: ({
-      subscriptionData: {
-        data: { updateOrderList },
-      },
-    }) => {
-      const { unassignedOrders: newOrderList } = updateOrderList;
+    onSubscriptionData: async () => {
+      const newData = await callQuery();
+      const { unassignedOrders: newOrderList } = newData?.data.getUnassignedOrders || {};
       setOrderData(newOrderList);
     },
   });

--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useEffect } from 'react';
+import { useSubscription } from '@apollo/client';
 import { useCustomQuery } from '@hooks/useApollo';
 
 import styled from '@theme/styled';
@@ -7,7 +8,7 @@ import MapFrame from '@components/MapFrame';
 import OrderLog from '@components/OrderLog';
 import Modal from '@components/Modal';
 import OrderModalItem from '@components/OrderModalItem';
-import { GET_UNASSIGNED_ORDERS } from '@queries/order.queries';
+import { GET_UNASSIGNED_ORDERS, UPDATE_ORDER_LIST } from '@queries/order.queries';
 import useModal from '@hooks/useModal';
 import {
   GetUnassignedOrders,
@@ -35,25 +36,45 @@ const StyledOrderLogList = styled.section`
 
 const Main: FC = () => {
   const { data: orders } = useCustomQuery<GetUnassignedOrders>(GET_UNASSIGNED_ORDERS);
+  const { unassignedOrders } = orders?.getUnassignedOrders || {};
+  const [orderData, setOrderData] = useState<Order[] | null | undefined>();
   const [isModal, openModal, closeModal] = useModal();
   const [orderItem, setOrderItem] = useState<Order>();
+  const { data } = useSubscription(UPDATE_ORDER_LIST, {
+    onSubscriptionData: ({
+      subscriptionData: {
+        data: { updateOrderList },
+      },
+    }) => {
+      const { unassignedOrders: newOrderList } = updateOrderList;
+      setOrderData(newOrderList);
+    },
+  });
 
   const onClickOrder = (order: Order) => {
     openModal();
     setOrderItem(order);
   };
 
+  useEffect(() => {
+    setOrderData(unassignedOrders);
+  }, [unassignedOrders]);
+
   return (
     <>
       <MapFrame>
         <StyledOrderLogList>
-          {orders?.getUnassignedOrders.unassignedOrders?.map((order) => (
-            <OrderLog
-              order={order}
-              key={`order_list_${order._id}`}
-              onClick={() => onClickOrder(order)}
-            />
-          )).length || <h1>현재 요청이 없습니다</h1>}
+          {orderData && orderData?.length !== 0 ? (
+            orderData?.map((order) => (
+              <OrderLog
+                order={order}
+                key={`order_list_${order._id}`}
+                onClick={() => onClickOrder(order)}
+              />
+            ))
+          ) : (
+            <h1>현재 요청이 없습니다</h1>
+          )}
         </StyledOrderLogList>
       </MapFrame>
       <Modal visible={isModal} onClose={closeModal}>

--- a/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
+++ b/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
@@ -1,18 +1,22 @@
 import { Resolvers } from '@type/api';
 import approvalOrder from '@services/order/approvalOrder';
+import { UPDATE_ORDER_LIST } from '@api/order/updateOrderList/updateOrderList.resolvers';
 
 export const APPROVAL_ORDER = 'APPROVAL_ORDER';
 
 const resolvers: Resolvers = {
   Mutation: {
     approvalOrder: async (_, { orderId }, { req, pubsub }) => {
-      const { result, error } = await approvalOrder(req.user?._id || '', orderId);
+      const { result, error, unassignedOrders } = await approvalOrder(req.user?._id || '', orderId);
 
       if (result === 'fail' || error) {
         return { result, error };
       }
 
       pubsub.publish(APPROVAL_ORDER, { subApprovalOrder: { approvalOrderId: orderId } });
+      pubsub.publish(UPDATE_ORDER_LIST, {
+        updateOrderList: { unassignedOrders, result: 'success' },
+      });
 
       return { result };
     },

--- a/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
+++ b/server/src/api/order/approvalOrder/approvalOrder.resolvers.ts
@@ -7,7 +7,7 @@ export const APPROVAL_ORDER = 'APPROVAL_ORDER';
 const resolvers: Resolvers = {
   Mutation: {
     approvalOrder: async (_, { orderId }, { req, pubsub }) => {
-      const { result, error, unassignedOrders } = await approvalOrder(req.user?._id || '', orderId);
+      const { result, error } = await approvalOrder(req.user?._id || '', orderId);
 
       if (result === 'fail' || error) {
         return { result, error };
@@ -15,7 +15,7 @@ const resolvers: Resolvers = {
 
       pubsub.publish(APPROVAL_ORDER, { subApprovalOrder: { approvalOrderId: orderId } });
       pubsub.publish(UPDATE_ORDER_LIST, {
-        updateOrderList: { unassignedOrders, result: 'success' },
+        updateOrderList: { result: 'success' },
       });
 
       return { result };

--- a/server/src/api/order/updateOrderList/updateOrderList.graphql
+++ b/server/src/api/order/updateOrderList/updateOrderList.graphql
@@ -1,3 +1,7 @@
+type UpdateOrderListResponse {
+  result: String!
+}
+
 type Subscription {
-  updateOrderList: GetUnassignedOrders!
+  updateOrderList: UpdateOrderListResponse!
 }

--- a/server/src/api/order/updateOrderList/updateOrderList.graphql
+++ b/server/src/api/order/updateOrderList/updateOrderList.graphql
@@ -1,0 +1,3 @@
+type Subscription {
+  updateOrderList: GetUnassignedOrders!
+}

--- a/server/src/api/order/updateOrderList/updateOrderList.resolvers.ts
+++ b/server/src/api/order/updateOrderList/updateOrderList.resolvers.ts
@@ -1,0 +1,13 @@
+import { Resolvers } from '@type/api';
+
+export const UPDATE_ORDER_LIST = 'UPDATE_ORDER_LIST';
+
+const resolvers: Resolvers = {
+  Subscription: {
+    updateOrderList: {
+      subscribe: (_, __, { pubsub }) => pubsub.asyncIterator(UPDATE_ORDER_LIST),
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/services/order/approvalOrder.ts
+++ b/server/src/services/order/approvalOrder.ts
@@ -1,12 +1,10 @@
 import Order from '@models/order';
-import getUnassignedOrders from '@services/order/getUnassingedOrders';
 
 const approvalOrder = async (driverId: string, orderId: string) => {
   try {
     await Order.findByIdAndUpdate(orderId, { driver: driverId, status: 'active' });
-    const { unassignedOrders } = await getUnassignedOrders(driverId || '');
 
-    return { result: 'success', unassignedOrders };
+    return { result: 'success' };
   } catch (err) {
     return { result: 'fail', error: err.message };
   }

--- a/server/src/services/order/approvalOrder.ts
+++ b/server/src/services/order/approvalOrder.ts
@@ -1,10 +1,12 @@
 import Order from '@models/order';
+import getUnassignedOrders from '@services/order/getUnassingedOrders';
 
 const approvalOrder = async (driverId: string, orderId: string) => {
   try {
     await Order.findByIdAndUpdate(orderId, { driver: driverId, status: 'active' });
+    const { unassignedOrders } = await getUnassignedOrders(driverId || '');
 
-    return { result: 'success' };
+    return { result: 'success', unassignedOrders };
   } catch (err) {
     return { result: 'fail', error: err.message };
   }


### PR DESCRIPTION
### 작업 사항
- [x] orderListUpdate subscription 구현
- [x] 클라이언트 orderListUpdate subscription 작성
- [x] subscription 발생 시 받은 데이터로 업데이트 하도록 구현


### 요약
- orderListUpdate가 오더 승인 Mutation을 구독하도록 하고, 오더 승인 Mutation 발생 시 승낙되지 않은 오더 리스트를 받아오도록 구현했습니다.
- 클라이언트 쪽에선 해당 뮤테이션 발생 시 받은 오더 리스트를 onSubscriptionData 함수를 이용하여 View에 업데이트 시키도록 했습니다.
- 코드가 전반적으로 맘에 썩 들진 않습니다ㅠㅠ 리팩토링 할 예정이고 감안해서 봐주시면 감사하겠습니다! (일단은 필수기능 모두 구현하는데 목표를 두기로 생각하고 구현했습니다!)

### 첨부
![Dec-01-2020 00-04-14](https://user-images.githubusercontent.com/52775389/100626162-ce8e9c00-3368-11eb-937d-fe5efe21c122.gif)

### 이슈
#93 