### PR TITLE
[CY] 사용자 드라이버 호출 취소 기능 구현

### DIFF
--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -67,7 +67,6 @@ export const SUB_APPROVAL_ORDER = gql`
   }
 `;
 
-
 export const GET_ORDER_CAR_INFO = gql`
   query GetOrderCarInfo($orderId: String!) {
     getOrderCarInfo(orderId: $orderId) {
@@ -85,6 +84,15 @@ export const UPDATE_ORDER_LIST = gql`
   subscription UpdateOrderList {
     updateOrderList {
       result
+    }
+  }
+`;
+
+export const CANCEL_ORDER = gql`
+  mutation CancelOrder($orderId: String!) {
+    cancelOrder(orderId: $orderId) {
+      result
+      error
     }
   }
 `;

--- a/client/src/utils/client-message.ts
+++ b/client/src/utils/client-message.ts
@@ -10,4 +10,5 @@ export const Message = {
   ExpiryDateGuidance: '예시: MM/YY',
   DriverAjacent: '차량이 곧 도착합니다.',
   DriverMatchingCompolete: '차량이 매칭되었습니다',
+  FailureCancelOrder: '드라이버 호출 취소에 실패했습니다',
 };


### PR DESCRIPTION
### 작업 사항
- [x] 클라이언트 오더 취소 기능 구현 (자동으로 드라이버의 오더 목록에서 삭제)

### 첨부
![cancelOrder](https://user-images.githubusercontent.com/49899406/100700857-d4749380-33e1-11eb-83d8-b94030216aff.gif)

### 이슈
#112 