### PR TITLE
[JE] 드라이버가 출발지로 이동하는 실시간 경로 보여주는 페이지 (탑승자 화면)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import ChatRoom from '@routes/ChatRoom';
 import SignIn from '@/routes/SignIn';
 import Home from '@routes/Home';
 import UserMain from '@routes/User/Main';
+import UserWaitingDriver from '@routes/User/WaitingDriver';
 import DriverMain from '@routes/Driver/Main';
 import DriverGoToOrigin from '@routes/Driver/GoToOrigin';
 import DriverGoToDestination from '@routes/Driver/GoToDestination';
@@ -34,6 +35,7 @@ const App: FC = () => (
           <Switch>
             <Route exact path="/" component={auth(Home)} />
             <Route exact path="/user" component={auth(UserMain, 'user')} />
+            <Route exact path="/user/waitingDriver" component={auth(UserWaitingDriver, 'user')} />
             <Route exact path="/driver" component={auth(DriverMain, 'driver')} />
             <Route exact path="/driver/goToOrigin" component={auth(DriverGoToOrigin, 'driver')} />
             <Route

--- a/client/src/queries/user.queries.ts
+++ b/client/src/queries/user.queries.ts
@@ -58,3 +58,11 @@ export const UPDATE_DRIVER_LOCATION = gql`
     }
   }
 `;
+
+export const SUB_DRIVER_LOCATION = gql`
+  subscription SubDriverLocation($orderId: String!) {
+    subDriverLocation(orderId: $orderId) {
+      coordinates
+    }
+  }
+`;

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from 'antd-mobile';
+import styled from '@theme/styled';
+import { useSubscription } from '@apollo/react-hooks';
+
+import MapFrame from '@components/MapFrame';
+import { GET_ORDER } from '@queries/order.queries';
+import { SUB_DRIVER_LOCATION } from '@queries/user.queries';
+import { GetOrderInfo, SubDriverLocation } from '@/types/api';
+import { useCustomQuery } from '@hooks/useApollo';
+
+const StyledWaitingDriverMenu = styled.section`
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+
+  & > .cancel-order-btn {
+    width: 100%;
+
+    & > .am-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      height: 2rem;
+      margin: 0.8rem 0;
+      font-weight: 700;
+      font-size: 0.9rem;
+    }
+  }
+`;
+
+const WaitingDriver = () => {
+  const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
+  const [driverLocation, setDriverLocation] = useState({ lat: 0, lng: 0 });
+  const { data } = useCustomQuery<GetOrderInfo>(GET_ORDER, {
+    variables: { orderId: '5fc45539e439ea40e869bf47' },
+  });
+  useSubscription<SubDriverLocation>(SUB_DRIVER_LOCATION, {
+    variables: { orderId: '5fc45539e439ea40e869bf47' },
+    onSubscriptionData: ({ subscriptionData }) => {
+      const driverNewLocation = subscriptionData.data?.subDriverLocation.coordinates as number[];
+      setDriverLocation({ lat: driverNewLocation[0], lng: driverNewLocation[1] });
+    },
+  });
+  const order = data?.getOrderInfo.order;
+
+  return (
+    <MapFrame
+      origin={driverLocation}
+      destination={{
+        lat: order?.startingPoint.coordinates[0] as number,
+        lng: order?.startingPoint.coordinates[1] as number,
+      }}
+      setDirections={setDirections}
+      directions={directions}
+    >
+      <StyledWaitingDriverMenu>
+        <div className="cancel-order-btn">
+          <Button type="warning">취소</Button>
+        </div>
+      </StyledWaitingDriverMenu>
+    </MapFrame>
+  );
+};
+
+export default WaitingDriver;

--- a/client/src/routes/User/WaitingDriver/index.ts
+++ b/client/src/routes/User/WaitingDriver/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WaitingDriver';

--- a/server/src/api/user/subLocation/subDriverLocation.graphql
+++ b/server/src/api/user/subLocation/subDriverLocation.graphql
@@ -4,5 +4,5 @@ type LocationWithOrderId {
 }
 
 type Subscription {
-    subLocation(orderId: String!): LocationWithOrderId!
+    subDriverLocation(orderId: String!): LocationWithOrderId!
 }

--- a/server/src/api/user/subLocation/subDriverLocation.resolvers.ts
+++ b/server/src/api/user/subLocation/subDriverLocation.resolvers.ts
@@ -9,7 +9,7 @@ const resolvers: Resolvers = {
       subscribe: withFilter(
         (_, __, { pubsub }) => pubsub.asyncIterator(UPDATE_DRIVER_LOCATION),
         (payload, variables) => {
-          return payload.subDriverLocation.orderId == variables.orderId;
+          return payload.subDriverLocation.orderId === variables.orderId;
         },
       ),
     },

--- a/server/src/api/user/subLocation/subDriverLocation.resolvers.ts
+++ b/server/src/api/user/subLocation/subDriverLocation.resolvers.ts
@@ -5,11 +5,11 @@ import { UPDATE_DRIVER_LOCATION } from '@api/user/updateDriverLocation/updateDri
 
 const resolvers: Resolvers = {
   Subscription: {
-    subLocation: {
+    subDriverLocation: {
       subscribe: withFilter(
         (_, __, { pubsub }) => pubsub.asyncIterator(UPDATE_DRIVER_LOCATION),
         (payload, variables) => {
-          return payload.subLocation.orderId == variables.orderId;
+          return payload.subDriverLocation.orderId == variables.orderId;
         },
       ),
     },

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -11,7 +11,6 @@ const resolvers: Resolvers = {
         userType: req.user?.type,
         curLocation: { coordinates: [lat, lng] },
       });
-      console.log(orderId);
       pubsub.publish(UPDATE_DRIVER_LOCATION, {
         subDriverLocation: { coordinates: [lat, lng], orderId },
       });

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -11,8 +11,9 @@ const resolvers: Resolvers = {
         userType: req.user?.type,
         curLocation: { coordinates: [lat, lng] },
       });
+      console.log(orderId);
       pubsub.publish(UPDATE_DRIVER_LOCATION, {
-        subLocation: { coordinates: [lat, lng], orderId },
+        subDriverLocation: { coordinates: [lat, lng], orderId },
       });
 
       if (result === 'fail') {

--- a/server/src/services/order/getOrder.ts
+++ b/server/src/services/order/getOrder.ts
@@ -18,14 +18,20 @@ interface Query {
 
 const getOrder = async ({ orderId, userId, userType }: GetOrderProps) => {
   try {
-    const query: Query = {
-      _id: orderId,
-      status: 'active',
-    };
-    if (userType === loginType.user) query.user = userId;
-    if (userType === loginType.driver) query.driver = userId;
-
-    const order = (await Order.findOne(query)) as OrderType | null;
+    let order;
+    if (userType === loginType.user) {
+      order = (await Order.findOne({
+        _id: orderId,
+        status: 'activate',
+        user: userId,
+      })) as OrderType | null;
+    } else if (userType === loginType.driver) {
+      order = (await Order.findOne({
+        _id: orderId,
+        status: 'activate',
+        driver: userId,
+      })) as OrderType | null;
+    }
 
     if (!order) {
       return { result: 'fail', order: null, error: Message.OrderNotFound };

--- a/server/src/services/user/updateDriverLocation.ts
+++ b/server/src/services/user/updateDriverLocation.ts
@@ -21,7 +21,7 @@ const updateDriverLocation = async ({ userId, userType, curLocation }: UpdateLoc
       },
     );
 
-    const order = await Order.findOne({ driver: userId, status: 'activate' });
+    const order = await Order.findOne({ driver: userId, status: 'active' });
 
     return { result: 'success', orderId: order?._id };
   } catch (err) {


### PR DESCRIPTION
### 작업 사항
- [x] 드라이버가 출발지까지 이동하는 경로를 확인하는 페이지 구현
- [x] 드라이버 위치 subscription
- [ ] 유효한 오더 아이디를 받아서 처리하도록 수정


### 요약
드라이버가 위치를 이동할 때 탑승자의 화면에서도 보이도록 구현하였습니다. 
현재 오더 아이디를 임의로 주고 있는데 오더아이디를 받아서 처리하도록 수정하는 부분이 남았습니다!
두 화면이 조금씩 안맞을 때가 있지만 리팩토링 하면서 정확도를 더 높이면 될 것 같습니다!

**
오더 정보 불러오는 서비스를 수정했는데 기존에 있던 query객체를 이용하면 오더를 불러오지 못하고 직접 객체를 넣어주면 불러오는 것을 확인했습니다. 둘의 차이를 찾이를 찾지 못해서 일단 동작하는 방식으로 수정했습니다.


### 첨부
빨리감기 했습니다!
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/43084680/100705809-37b6f380-33eb-11eb-9931-74fb381314dc.gif)

### 이슈
#84 