### PR TITLE
[HJ] 오더조회 서비스로직분리/ 오더 중복 수락 방지

### DIFF
--- a/client/src/components/OrderModalItem/OrderModalItem.tsx
+++ b/client/src/components/OrderModalItem/OrderModalItem.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-useless-return */
-/* eslint-disable no-underscore-dangle */
 import React, { FC, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -31,6 +31,18 @@ export const GET_ORDER = gql`
   }
 `;
 
+export const GET_ORDER_BY_ID = gql`
+  query getOrderById($orderId: String!) {
+    getOrderById(orderId: $orderId) {
+      result
+      order {
+        status
+      }
+      error
+    }
+  }
+`;
+
 export const GET_UNASSIGNED_ORDERS = gql`
   query GetUnassignedOrders {
     getUnassignedOrders {

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -24,6 +24,7 @@ export const GET_ORDER = gql`
           address
           coordinates
         }
+        status
       }
       error
     }

--- a/client/src/utils/client-message.ts
+++ b/client/src/utils/client-message.ts
@@ -11,4 +11,5 @@ export const Message = {
   DriverAjacent: '차량이 곧 도착합니다.',
   DriverMatchingCompolete: '차량이 매칭되었습니다',
   FailureCancelOrder: '드라이버 호출 취소에 실패했습니다',
+  FailureMatchingOrder: '이미 매칭된 요청입니다.',
 };

--- a/client/src/utils/enums.ts
+++ b/client/src/utils/enums.ts
@@ -6,6 +6,7 @@ export enum TOAST_DURATION {
 
   SIGNIN_SUCCESS = 0.5,
   SIGNIN_FAILURE = 2,
+  MATCHING_FAILURE = 2,
 }
 
 export enum DRIVER {

--- a/server/src/api/order/getOrderById/getOrderById.graphql
+++ b/server/src/api/order/getOrderById/getOrderById.graphql
@@ -1,0 +1,9 @@
+type GetOrder {
+  result: String!
+  order: Order
+  error: String
+}
+
+type Query {
+  getOrderById(orderId: String!): GetOrder! @auth
+}

--- a/server/src/api/order/getOrderById/getOrderById.resolvers.ts
+++ b/server/src/api/order/getOrderById/getOrderById.resolvers.ts
@@ -1,0 +1,18 @@
+import { Resolvers } from '@type/api';
+
+import getOrderById from '@services/order/getOrderById';
+
+const resolvers: Resolvers = {
+  Query: {
+    getOrderById: async (_, { orderId }, { req }) => {
+      const { result, order, error } = await getOrderById(orderId);
+      if (!order && result === 'fail') {
+        return { result: 'fail', order, error };
+      }
+
+      return { result, order, error };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/order/shared/order.graphql
+++ b/server/src/api/order/shared/order.graphql
@@ -1,6 +1,6 @@
 enum OrderStatus {
     close
-    wating
+    waiting
     active
 }
 

--- a/server/src/api/order/shared/order.graphql
+++ b/server/src/api/order/shared/order.graphql
@@ -1,5 +1,6 @@
 enum OrderStatus {
     close
+    wating
     active
 }
 

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -17,7 +17,7 @@ const resolvers: Resolvers = {
         return { result, error };
       }
 
-      const { inquiryResult, order, inquiryError } = await getActiveDriverOrder(
+      const { result: inquiryResult, order, error: inquiryError } = await getActiveDriverOrder(
         req.user?._id || '',
       );
       if (inquiryResult === 'success' && order) {

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -1,4 +1,5 @@
 import { Resolvers } from '@type/api';
+import getActiveDriverOrder from '@services/order/getActiveDriverOrder';
 import updateDriverLocation from '@services/user/updateDriverLocation';
 
 export const UPDATE_DRIVER_LOCATION = 'UPDATE_DRIVER_LOCATION';
@@ -6,17 +7,26 @@ export const UPDATE_DRIVER_LOCATION = 'UPDATE_DRIVER_LOCATION';
 const resolvers: Resolvers = {
   Mutation: {
     updateDriverLocation: async (_, { lat, lng }, { req, pubsub }) => {
-      const { result, orderId, error } = await updateDriverLocation({
+      const { result, error } = await updateDriverLocation({
         userId: req.user?._id,
         userType: req.user?.type,
         curLocation: { coordinates: [lat, lng] },
       });
-      pubsub.publish(UPDATE_DRIVER_LOCATION, {
-        subDriverLocation: { coordinates: [lat, lng], orderId },
-      });
 
       if (result === 'fail') {
         return { result, error };
+      }
+
+      const { inquiryResult, order, inquiryError } = await getActiveDriverOrder(
+        req.user?._id || '',
+      );
+      if (inquiryResult === 'success' && order) {
+        pubsub.publish(UPDATE_DRIVER_LOCATION, {
+          subDriverLocation: { coordinates: [lat, lng], orderId: order._id },
+        });
+      }
+      if (inquiryResult === 'fail') {
+        return { result: inquiryResult, error: inquiryError };
       }
 
       return { result };

--- a/server/src/services/order/getActiveDriverOrder.ts
+++ b/server/src/services/order/getActiveDriverOrder.ts
@@ -1,0 +1,16 @@
+import Order from '@models/order';
+import { Order as OrderType } from '@type/api';
+
+const getActiveDriverOrder = async (driverId: string) => {
+  try {
+    const order = (await Order.findOne({
+      driver: driverId,
+      status: 'active',
+    })) as OrderType | null;
+    return { inquiryResult: 'success', order };
+  } catch (err) {
+    return { inquiryResult: 'fail', inquiryError: err.message };
+  }
+};
+
+export default getActiveDriverOrder;

--- a/server/src/services/order/getActiveDriverOrder.ts
+++ b/server/src/services/order/getActiveDriverOrder.ts
@@ -7,9 +7,9 @@ const getActiveDriverOrder = async (driverId: string) => {
       driver: driverId,
       status: 'active',
     })) as OrderType | null;
-    return { inquiryResult: 'success', order };
+    return { result: 'success', order };
   } catch (err) {
-    return { inquiryResult: 'fail', inquiryError: err.message };
+    return { result: 'fail', error: err.message };
   }
 };
 

--- a/server/src/services/order/getOrder.ts
+++ b/server/src/services/order/getOrder.ts
@@ -9,13 +9,6 @@ interface GetOrderProps {
   userType?: LoginType;
 }
 
-interface Query {
-  _id: string;
-  user?: string;
-  driver?: string;
-  status: string;
-}
-
 const getOrder = async ({ orderId, userId, userType }: GetOrderProps) => {
   try {
     let order;

--- a/server/src/services/order/getOrderById.ts
+++ b/server/src/services/order/getOrderById.ts
@@ -1,0 +1,18 @@
+import { Order as OrderType } from '@type/api';
+import Order from '@models/order';
+import { Message } from '@util/server-message';
+
+const getOrderById = async (orderId: string) => {
+  try {
+    const order = (await Order.findById(orderId)) as OrderType | null;
+
+    if (!order) {
+      return { result: 'fail', order: null, error: Message.OrderNotFound };
+    }
+    return { result: 'success', order };
+  } catch (err) {
+    return { result: 'fail', order: null, error: err.message };
+  }
+};
+
+export default getOrderById;

--- a/server/src/services/user/updateDriverLocation.ts
+++ b/server/src/services/user/updateDriverLocation.ts
@@ -21,9 +21,7 @@ const updateDriverLocation = async ({ userId, userType, curLocation }: UpdateLoc
       },
     );
 
-    const order = await Order.findOne({ driver: userId, status: 'active' });
-
-    return { result: 'success', orderId: order?._id };
+    return { result: 'success' };
   } catch (err) {
     return { result: 'fail', error: err.message };
   }


### PR DESCRIPTION
### 작업 사항
- [x] 오더조회 서비스로직분리
- [x] 오더 중복 수락 방지


### 요약
오더 중복 수락 방지를 위해 오더 조회할때 id 로만 order 를 조회하는 쿼리가 없어서 새로하나 만들었습니다.

### 첨부
![깃업풀리쾌](https://user-images.githubusercontent.com/49400477/100814434-07bc2e80-3485-11eb-8478-f903d0173c7f.PNG)

### 이슈
#130 