### PR TITLE
[CY] 드라이버 운행 시작 시 사용자 페이지 변경

### DIFF
--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -128,3 +128,12 @@ export const CANCEL_ORDER = gql`
     }
   }
 `;
+
+export const START_DRIVING = gql`
+  mutation StartDriving($orderId: String!) {
+    startDriving(orderId: $orderId) {
+      result
+      error
+    }
+  }
+`;

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -5,9 +5,9 @@ import { useSelector } from 'react-redux';
 import styled from '@theme/styled';
 
 import MapFrame from '@components/MapFrame';
-import { GET_ORDER } from '@queries/order.queries';
+import { GET_ORDER, START_DRIVING } from '@queries/order.queries';
 import { UPDATE_DRIVER_LOCATION } from '@queries/user.queries';
-import { GetOrderInfo, UpdateDriverLocation } from '@/types/api';
+import { GetOrderInfo, UpdateDriverLocation, StartDriving } from '@/types/api';
 import getUserLocation from '@utils/getUserLocation';
 import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 import { InitialState } from '@reducers/.';
@@ -48,6 +48,13 @@ const GoToOrigin = () => {
   const [updateDriverLocationMutation] = useCustomMutation<UpdateDriverLocation>(
     UPDATE_DRIVER_LOCATION,
   );
+  const [startDrivingMutation] = useCustomMutation<StartDriving>(START_DRIVING, {
+    onCompleted: ({ startDriving }) => {
+      if (startDriving?.result === 'success') {
+        history.push('/driver/goToDestination');
+      }
+    },
+  });
   const history = useHistory();
   const order = data?.getOrderInfo.order;
 
@@ -63,8 +70,8 @@ const GoToOrigin = () => {
   };
 
   const onClickStartDrive = useCallback(() => {
-    history.push('/driver/goToDestination');
-  }, []);
+    startDrivingMutation({ variables: { orderId: id } });
+  }, [id]);
 
   useEffect(() => {
     const updateCurrentLocationInterval = setInterval(updateCurrentLocation, 5000);

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -6,14 +6,16 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
 import MapFrame from '@components/MapFrame';
-import { GET_ORDER, GET_ORDER_CAR_INFO } from '@queries/order.queries';
+import { GET_ORDER, GET_ORDER_CAR_INFO, SUB_ORDER_CALL_STATUS } from '@queries/order.queries';
 import { SUB_DRIVER_LOCATION } from '@queries/user.queries';
 import {
   GetOrderInfo,
   SubDriverLocation,
   GetOrderCarInfo,
   CarInfo as CarInfoType,
+  SubOrderCallStatus,
 } from '@/types/api';
+import { OrderCallStatus } from '@/types/orderCallStatus';
 import { useCustomQuery } from '@hooks/useApollo';
 import { calcLocationDistance } from '@utils/calcLocationDistance';
 import CarInfo from '@components/CarInfo';
@@ -79,6 +81,14 @@ const WaitingDriver = () => {
       if (didCloseModal === false && calcLocationDistance(driverNewLocation, destination) < 100) {
         openModal();
         setDidCloseModal(true);
+      }
+    },
+  });
+  useSubscription<SubOrderCallStatus>(SUB_ORDER_CALL_STATUS, {
+    variables: { orderId: id },
+    onSubscriptionData: ({ subscriptionData }) => {
+      if (subscriptionData.data?.subOrderCallStatus.status === OrderCallStatus.startedDrive) {
+        history.push('/user/goToDestination');
       }
     },
   });

--- a/server/src/api/order/startDriving/startDriving.graphql
+++ b/server/src/api/order/startDriving/startDriving.graphql
@@ -1,0 +1,8 @@
+type StartDrivingResponse {
+    result: String!
+    error: String
+}
+
+type Mutation {
+    startDriving(orderId: String!): StartDrivingResponse @auth
+}

--- a/server/src/api/order/startDriving/startDriving.resolvers.ts
+++ b/server/src/api/order/startDriving/startDriving.resolvers.ts
@@ -1,0 +1,19 @@
+import { Resolvers } from '@type/api';
+
+import {
+  ORDER_CALL_STATUS,
+  OrderCallStatus,
+} from '@api/order/subOrderCallStatus/subOrderCallStatus.resolvers';
+
+const resolvers: Resolvers = {
+  Mutation: {
+    startDriving: (_, { orderId }, { pubsub }) => {
+      pubsub.publish(ORDER_CALL_STATUS, {
+        subOrderCallStatus: { orderId, status: OrderCallStatus.STARTED_DRIVE },
+      });
+      return { result: 'success' };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/order/subOrderCallStatus/subOrderCallStatus.resolvers.ts
+++ b/server/src/api/order/subOrderCallStatus/subOrderCallStatus.resolvers.ts
@@ -6,7 +6,7 @@ export const ORDER_CALL_STATUS = 'ORDER_CALL_STATUS';
 // eslint-disable-next-line no-shadow
 export const enum OrderCallStatus {
   APPROVAL = 'approval',
-  STARED_DRIVE = 'startedDrive',
+  STARTED_DRIVE = 'startedDrive',
   COMPLETED_DRIVE = 'completedDrive',
 }
 


### PR DESCRIPTION
### 작업 사항
- [x] 드라이버 운행 시작 Mutation 구현
- [x] 드라이버 운행 시작 버튼 클릭 이벤트 적용
- [x] 드라이버 운행 시작 시 사용자 페이지 `user/goToDestination`로 변경


### 요약
드라이버 운행 시작 시 사용자 페이지 변경
사용자의 `goToDestination`페이지는 다음 기능에서 구현할 예정


### 첨부
![startDriving](https://user-images.githubusercontent.com/49899406/100869325-429f8000-34e0-11eb-8b2a-42fb94acbb7a.gif)


### 이슈
#140 