### PR TITLE
[CY] origin, descrition 데이터 로컬 컴포넌트에서 redux 전역 스토어로 관리

### DIFF
--- a/client/src/components/EstimatedTime/EstimatedTime.tsx
+++ b/client/src/components/EstimatedTime/EstimatedTime.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect } from 'react';
 
 import styled from '@theme/styled';
-import { Location } from '@components/GoogleMap';
+import { Location } from '@reducers/.';
 
 interface Props {
   directions: google.maps.DirectionsResult | undefined;

--- a/client/src/components/EstimatedTime/EstimatedTime.tsx
+++ b/client/src/components/EstimatedTime/EstimatedTime.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
+import { useSelector } from 'react-redux';
 
 import styled from '@theme/styled';
-import { Location } from '@reducers/.';
+import { InitialState } from '@reducers/.';
 
 interface Props {
   directions: google.maps.DirectionsResult | undefined;
-  origin?: Location;
-  destination?: Location;
 }
 
 const StyledEstimatedTime = styled.div`
@@ -24,7 +23,8 @@ const StyledEstimatedTime = styled.div`
   }
 `;
 
-const EstimatedTime: FC<Props> = ({ directions, origin, destination }) => {
+const EstimatedTime: FC<Props> = ({ directions }) => {
+  const { origin, destination } = useSelector(({ order }: InitialState) => order.location);
   const estimatedTime = directions?.routes[0].legs[0].duration;
   const estimatedDistance = directions?.routes[0].legs[0].distance;
 

--- a/client/src/components/GoogleMap/Directions.tsx
+++ b/client/src/components/GoogleMap/Directions.tsx
@@ -2,7 +2,7 @@ import React, { FC, useRef, useEffect } from 'react';
 
 import { DirectionsService, DirectionsRenderer } from '@react-google-maps/api';
 
-import { Location } from './GoogleMap';
+import { Location } from '@reducers/.';
 
 interface Props {
   origin: Location;

--- a/client/src/components/GoogleMap/GoogleMap.tsx
+++ b/client/src/components/GoogleMap/GoogleMap.tsx
@@ -2,14 +2,9 @@ import React, { FC, useState, useEffect, useCallback } from 'react';
 
 import { GoogleMap as GoogleMapComponent, Marker } from '@react-google-maps/api';
 import getUserLocation from '@utils/getUserLocation';
+import { Location } from '@reducers/.';
 
 import Directions from './Directions';
-
-export interface Location {
-  address?: string;
-  lat: number;
-  lng: number;
-}
 
 interface Props {
   origin?: Location;

--- a/client/src/components/GoogleMap/index.ts
+++ b/client/src/components/GoogleMap/index.ts
@@ -1,3 +1,1 @@
 export { default } from './GoogleMap';
-
-export type { Location } from './GoogleMap';

--- a/client/src/components/MapFrame/MapFrame.tsx
+++ b/client/src/components/MapFrame/MapFrame.tsx
@@ -2,7 +2,8 @@ import React, { FC, useState, useEffect } from 'react';
 import { Loader } from '@googlemaps/js-api-loader';
 
 import styled from '@theme/styled';
-import GoogleMap, { Location } from '@components/GoogleMap';
+import GoogleMap from '@components/GoogleMap';
+import { Location } from '@reducers//';
 import HeaderWithMenu from '@components/HeaderWithMenu';
 
 interface Props {

--- a/client/src/components/OrderModalItem/OrderModalItem.tsx
+++ b/client/src/components/OrderModalItem/OrderModalItem.tsx
@@ -4,6 +4,8 @@ import { useDispatch } from 'react-redux';
 import { Button, Toast } from 'antd-mobile';
 
 import { addOrderId } from '@reducers/order';
+import { updateLocationALL } from '@reducers/location';
+import { Location } from '@reducers/.';
 import styled from '@theme/styled';
 import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 import { APPROVAL_ORDER, GET_ORDER_BY_ID } from '@queries/order.queries';
@@ -11,6 +13,7 @@ import {
   getOrderById,
   ApprovalOrder,
   GetUnassignedOrders_getUnassignedOrders_unassignedOrders as UnassignedOrder,
+  GetUnassignedOrders_getUnassignedOrders_unassignedOrders_startingPoint as ServerLocation,
 } from '@/types/api';
 import { TOAST_DURATION } from '@utils/enums';
 import { Message } from '@utils/client-message';
@@ -19,6 +22,12 @@ interface Props {
   order: UnassignedOrder;
   closeModal: () => void;
 }
+
+const localLocationMapper = (location: ServerLocation): Location => ({
+  address: location.address,
+  lat: location.coordinates[0],
+  lng: location.coordinates[1],
+});
 
 const StyledOrderItem = styled.div`
   font-size: 1rem;
@@ -72,6 +81,12 @@ const OrderModalItem: FC<Props> = ({ order, closeModal }) => {
       }
       if (status === 'waiting') {
         dispatch(addOrderId(order._id));
+        dispatch(
+          updateLocationALL({
+            origin: localLocationMapper(order.startingPoint),
+            destination: localLocationMapper(order.destination),
+          }),
+        );
         approvalOrder({ variables: { orderId: order._id } });
         return history.push('/driver/goToOrigin');
       }

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,5 +1,6 @@
 import { CarInfo } from '@/types/api';
 import { OrderActions, ADD_ORDER_ID, ADD_CAR_INFO } from './order';
+import { LocationActions, UPDATE_LOCATION_ORIGIN, UPDATE_LOCATION_DESTINATION } from './location';
 
 interface Driver {
   licenseNumber: string;
@@ -31,14 +32,22 @@ export interface InitialState {
 
 const initialState: InitialState = { location: { isFixCenter: false } };
 
-type Action = OrderActions;
+type Action = OrderActions | LocationActions;
 
 const reducer = (state: InitialState = initialState, action: Action): InitialState => {
   switch (action.type) {
+    // order
     case ADD_ORDER_ID:
       return { ...state, order: { ...state.order, id: action.orderId } };
     case ADD_CAR_INFO:
       return { ...state, order: { ...state.order, carInfo: action.carInfo } };
+
+    // location
+    case UPDATE_LOCATION_ORIGIN:
+      return { ...state, location: { ...state.location, origin: action.location } };
+    case UPDATE_LOCATION_DESTINATION:
+      return { ...state, location: { ...state.location, destination: action.location } };
+
     default:
       return state;
   }

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -6,6 +6,12 @@ interface Driver {
   status: string;
 }
 
+export interface Location {
+  address?: string;
+  lat: number;
+  lng: number;
+}
+
 export interface InitialState {
   user?: {
     _id: string;
@@ -16,9 +22,14 @@ export interface InitialState {
     id?: string;
     carInfo?: CarInfo;
   };
+  location: {
+    isFixCenter: boolean;
+    origin?: Location;
+    destination?: Location;
+  };
 }
 
-const initialState: InitialState = {};
+const initialState: InitialState = { location: { isFixCenter: false } };
 
 type Action = OrderActions;
 

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,6 +1,11 @@
 import { CarInfo } from '@/types/api';
 import { OrderActions, ADD_ORDER_ID, ADD_CAR_INFO } from './order';
-import { LocationActions, UPDATE_LOCATION_ORIGIN, UPDATE_LOCATION_DESTINATION } from './location';
+import {
+  LocationActions,
+  UPDATE_LOCATION_ORIGIN,
+  UPDATE_LOCATION_DESTINATION,
+  UPDATE_LOCATION_ALL,
+} from './location';
 
 interface Driver {
   licenseNumber: string;
@@ -62,6 +67,18 @@ const reducer = (state: InitialState = initialState, action: Action): InitialSta
           location: {
             ...state.order.location,
             destination: action.location,
+          },
+        },
+      };
+    case UPDATE_LOCATION_ALL:
+      return {
+        ...state,
+        order: {
+          ...state.order,
+          location: {
+            ...state.order.location,
+            origin: action.origin,
+            destination: action.destination,
           },
         },
       };

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -19,18 +19,18 @@ export interface InitialState {
     name: string;
     driver?: Driver;
   };
-  order?: {
+  order: {
     id?: string;
     carInfo?: CarInfo;
-  };
-  location: {
-    isFixCenter: boolean;
-    origin?: Location;
-    destination?: Location;
+    location: {
+      isFixCenter: boolean;
+      origin?: Location;
+      destination?: Location;
+    };
   };
 }
 
-const initialState: InitialState = { location: { isFixCenter: false } };
+const initialState: InitialState = { order: { location: { isFixCenter: false } } };
 
 type Action = OrderActions | LocationActions;
 
@@ -44,9 +44,27 @@ const reducer = (state: InitialState = initialState, action: Action): InitialSta
 
     // location
     case UPDATE_LOCATION_ORIGIN:
-      return { ...state, location: { ...state.location, origin: action.location } };
+      return {
+        ...state,
+        order: {
+          ...state.order,
+          location: {
+            ...state.order.location,
+            origin: action.location,
+          },
+        },
+      };
     case UPDATE_LOCATION_DESTINATION:
-      return { ...state, location: { ...state.location, destination: action.location } };
+      return {
+        ...state,
+        order: {
+          ...state.order,
+          location: {
+            ...state.order.location,
+            destination: action.location,
+          },
+        },
+      };
 
     default:
       return state;

--- a/client/src/reducers/location.ts
+++ b/client/src/reducers/location.ts
@@ -2,6 +2,7 @@ import { Location } from '.';
 
 export const UPDATE_LOCATION_ORIGIN = 'UPDATE_LOCATION_ORIGIN';
 export const UPDATE_LOCATION_DESTINATION = 'UPDATE_LOCATION_DESTINATION';
+export const UPDATE_LOCATION_ALL = 'UPDATE_LOCATION_ALL';
 
 // updateLocationOrigin
 export interface UpdateLocationOrigin {
@@ -25,4 +26,17 @@ export const updateLocationDestination = (location: Location): UpdateLocationDes
   location,
 });
 
-export type LocationActions = UpdateLocationOrigin | UpdateLocationDestination;
+// updateLocationAll
+export interface UpdateLocationAll {
+  type: typeof UPDATE_LOCATION_ALL;
+  origin: Location;
+  destination: Location;
+}
+
+export const updateLocationALL = (origin: Location, destination: Location): UpdateLocationAll => ({
+  type: UPDATE_LOCATION_ALL,
+  origin,
+  destination,
+});
+
+export type LocationActions = UpdateLocationOrigin | UpdateLocationDestination | UpdateLocationAll;

--- a/client/src/reducers/location.ts
+++ b/client/src/reducers/location.ts
@@ -7,10 +7,10 @@ export const UPDATE_LOCATION_ALL = 'UPDATE_LOCATION_ALL';
 // updateLocationOrigin
 export interface UpdateLocationOrigin {
   type: typeof UPDATE_LOCATION_ORIGIN;
-  location: Location;
+  location?: Location;
 }
 
-export const updateLocationOrigin = (location: Location): UpdateLocationOrigin => ({
+export const updateLocationOrigin = (location?: Location): UpdateLocationOrigin => ({
   type: UPDATE_LOCATION_ORIGIN,
   location,
 });
@@ -18,22 +18,30 @@ export const updateLocationOrigin = (location: Location): UpdateLocationOrigin =
 // updateLocationDestination
 export interface UpdateLocationDestination {
   type: typeof UPDATE_LOCATION_DESTINATION;
-  location: Location;
+  location?: Location;
 }
 
-export const updateLocationDestination = (location: Location): UpdateLocationDestination => ({
+export const updateLocationDestination = (location?: Location): UpdateLocationDestination => ({
   type: UPDATE_LOCATION_DESTINATION,
   location,
 });
 
 // updateLocationAll
-export interface UpdateLocationAll {
-  type: typeof UPDATE_LOCATION_ALL;
-  origin: Location;
-  destination: Location;
+interface UpdateLocationAllProps {
+  origin?: Location;
+  destination?: Location;
 }
 
-export const updateLocationALL = (origin: Location, destination: Location): UpdateLocationAll => ({
+export interface UpdateLocationAll {
+  type: typeof UPDATE_LOCATION_ALL;
+  origin?: Location;
+  destination?: Location;
+}
+
+export const updateLocationALL = ({
+  origin,
+  destination,
+}: UpdateLocationAllProps): UpdateLocationAll => ({
   type: UPDATE_LOCATION_ALL,
   origin,
   destination,

--- a/client/src/reducers/location.ts
+++ b/client/src/reducers/location.ts
@@ -1,0 +1,28 @@
+import { Location } from '.';
+
+export const UPDATE_LOCATION_ORIGIN = 'UPDATE_LOCATION_ORIGIN';
+export const UPDATE_LOCATION_DESTINATION = 'UPDATE_LOCATION_DESTINATION';
+
+// updateLocationOrigin
+export interface UpdateLocationOrigin {
+  type: typeof UPDATE_LOCATION_ORIGIN;
+  location: Location;
+}
+
+export const updateLocationOrigin = (location: Location): UpdateLocationOrigin => ({
+  type: UPDATE_LOCATION_ORIGIN,
+  location,
+});
+
+// updateLocationDestination
+export interface UpdateLocationDestination {
+  type: typeof UPDATE_LOCATION_DESTINATION;
+  location: Location;
+}
+
+export const updateLocationDestination = (location: Location): UpdateLocationDestination => ({
+  type: UPDATE_LOCATION_DESTINATION,
+  location,
+});
+
+export type LocationActions = UpdateLocationOrigin | UpdateLocationDestination;

--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -1,16 +1,17 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
 import MapFrame from '@/components/MapFrame';
-import { GET_ORDER } from '@queries/order.queries';
 import { UPDATE_DRIVER_LOCATION } from '@queries/user.queries';
-import { GetOrderInfo, UpdateDriverLocation } from '@/types/api';
-import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
+import { UpdateDriverLocation } from '@/types/api';
+import { useCustomMutation } from '@hooks/useApollo';
 import { Button } from 'antd-mobile';
 import styled from '@/theme/styled';
 import getUserLocation from '@utils/getUserLocation';
 import { DRIVER } from '@utils/enums';
 import { numberWithCommas } from '@utils/numberWithCommas';
-import { useSelector } from 'react-redux';
+
 import { InitialState } from '@reducers/.';
 
 const StyledGoToDestinationMenu = styled.div`
@@ -46,10 +47,9 @@ const GoToDestination: FC = () => {
   const history = useHistory();
   const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
   const [currentLocation, setCurrentLocation] = useState({ lat: 0, lng: 0 });
-  const [destination, setDestination] = useState({ lat: 0, lng: 0 });
   const [taxiFee, setTaxiFee] = useState(DRIVER.BASE_TAXI_FEE);
-  const { id } = useSelector((state: InitialState) => state.order || {});
-  const { callQuery } = useCustomQuery<GetOrderInfo>(GET_ORDER, { skip: true });
+  const { id } = useSelector(({ order }: InitialState) => order || {});
+  const { destination } = useSelector(({ order }: InitialState) => order.location || {});
   const [updateDriverLocationMutation] = useCustomMutation<UpdateDriverLocation>(
     UPDATE_DRIVER_LOCATION,
   );
@@ -69,12 +69,6 @@ const GoToDestination: FC = () => {
   };
 
   useEffect(() => {
-    (async () => {
-      const result = await callQuery({ orderId: id });
-      const lat = result?.data.getOrderInfo.order?.destination.coordinates[0] as number;
-      const lng = result?.data.getOrderInfo.order?.destination.coordinates[1] as number;
-      setDestination({ lat, lng });
-    })();
     const updateCurrentLocationInterval = setInterval(updateCurrentLocation, 5000);
     return () => {
       clearInterval(updateCurrentLocationInterval);

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button } from 'antd-mobile';
 import { useSelector } from 'react-redux';
@@ -38,13 +38,11 @@ const StyledDriverGoToOriginMenu = styled.section`
   }
 `;
 
-const GoToOrigin = () => {
+const GoToOrigin: FC = () => {
   const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
   const [currentLocation, setCurrentLocation] = useState({ lat: 0, lng: 0 });
-  const { id } = useSelector((state: InitialState) => state.order || {});
-  const { data } = useCustomQuery<GetOrderInfo>(GET_ORDER, {
-    variables: { orderId: id },
-  });
+  const { id } = useSelector(({ order }: InitialState) => order || {});
+  const { origin: userOrigin } = useSelector(({ order }: InitialState) => order.location || {});
   const [updateDriverLocationMutation] = useCustomMutation<UpdateDriverLocation>(
     UPDATE_DRIVER_LOCATION,
   );
@@ -56,7 +54,6 @@ const GoToOrigin = () => {
     },
   });
   const history = useHistory();
-  const order = data?.getOrderInfo.order;
 
   const updateCurrentLocation = async () => {
     const currLocation = await getUserLocation();
@@ -83,13 +80,10 @@ const GoToOrigin = () => {
 
   return (
     <>
-      {order && (
+      {userOrigin && (
         <MapFrame
           origin={currentLocation}
-          destination={{
-            lat: Number(order?.startingPoint.coordinates[0].toFixed(8)),
-            lng: Number(order?.startingPoint.coordinates[1].toFixed(8)),
-          }}
+          destination={userOrigin}
           setDirections={setDirections}
           directions={directions}
         >

--- a/client/src/routes/User/Main/Main.tsx
+++ b/client/src/routes/User/Main/Main.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useState, useCallback } from 'react';
 import { Toast, Button } from 'antd-mobile';
 import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import AutoLocation from '@components/AutoLocation';
 import MapFrame from '@components/MapFrame';
 import EstimatedTime from '@components/EstimatedTime';
-import { Location } from '@reducers/.';
+import { Location, InitialState } from '@reducers/.';
 import { useCustomMutation } from '@hooks/useApollo';
 import { CREATE_ORDER } from '@queries/order.queries';
 import { CreateOrder } from '@/types/api';
@@ -41,8 +41,7 @@ const Main: FC = () => {
       Toast.fail('라이더 탐색에 실패했습니다', TOAST_MESSAGE_DURATION);
     },
   });
-  const [origin, setOrigin] = useState<Location>();
-  const [destination, setDestination] = useState<Location>();
+  const { origin, destination } = useSelector(({ order }: InitialState) => order.location);
   const [directions, setDirections] = useState<google.maps.DirectionsResult | undefined>(undefined);
 
   const onClickSearchDriver = useCallback(() => {
@@ -71,8 +70,8 @@ const Main: FC = () => {
       setDirections={setDirections}
       directions={directions}
     >
-      <AutoLocation setPosition={setOrigin} />
-      <AutoLocation setPosition={setDestination} />
+      <AutoLocation locationType="origin" />
+      <AutoLocation locationType="destination" />
       <EstimatedTime directions={directions} origin={origin} destination={destination} />
       <StyledButton type="primary" onClick={onClickSearchDriver}>
         라이더 탐색

--- a/client/src/routes/User/Main/Main.tsx
+++ b/client/src/routes/User/Main/Main.tsx
@@ -72,7 +72,7 @@ const Main: FC = () => {
     >
       <AutoLocation locationType="origin" />
       <AutoLocation locationType="destination" />
-      <EstimatedTime directions={directions} origin={origin} destination={destination} />
+      <EstimatedTime directions={directions} />
       <StyledButton type="primary" onClick={onClickSearchDriver}>
         라이더 탐색
       </StyledButton>

--- a/client/src/routes/User/Main/Main.tsx
+++ b/client/src/routes/User/Main/Main.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux';
 import AutoLocation from '@components/AutoLocation';
 import MapFrame from '@components/MapFrame';
 import EstimatedTime from '@components/EstimatedTime';
-import { Location } from '@components/GoogleMap';
+import { Location } from '@reducers/.';
 import { useCustomMutation } from '@hooks/useApollo';
 import { CREATE_ORDER } from '@queries/order.queries';
 import { CreateOrder } from '@/types/api';

--- a/client/src/utils/calcLocationDistance.ts
+++ b/client/src/utils/calcLocationDistance.ts
@@ -1,4 +1,4 @@
-import { Location } from '@components/GoogleMap';
+import { Location } from '@reducers/.';
 
 const rad = (x: number): number => {
   return (x * Math.PI) / 180;

--- a/client/src/utils/getUserLocation.ts
+++ b/client/src/utils/getUserLocation.ts
@@ -1,4 +1,4 @@
-import { Location } from '@components/GoogleMap';
+import { Location } from '@reducers/.';
 
 const getUserLocation = async (): Promise<Location | void> => {
   try {


### PR DESCRIPTION
### 작업 사항
- [x] redux에 origin, description 추가 로직 구현
- [x] 기존에 사용되던 origin, description을 redux에서 사용하도록 변경


### 요약
origin, descrition 데이터 로컬 컴포넌트에서 redux 전역 스토어로 관리
redux를 적용하며 getOrder쿼리를 대부분 지웠는데 추후에 로그인 후 유저데이터를 가져올 때 사용할 예정
(기존에 오더가 있더면 초기 오더데이터를 가져오는데 사용)


### 이슈
#145 