### PR TITLE
[HJ, JH] 드라이버위치 이동시마다 오더리스트(10km 이내) 갱신

### DIFF
--- a/client/src/routes/Driver/Main/Main.tsx
+++ b/client/src/routes/Driver/Main/Main.tsx
@@ -1,21 +1,23 @@
 /* eslint-disable no-underscore-dangle */
 import React, { FC, useState, useEffect } from 'react';
 import { useSubscription } from '@apollo/client';
-import { useCustomQuery } from '@hooks/useApollo';
-
+import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
+import {
+  UpdateDriverLocation,
+  GetUnassignedOrders,
+  GetUnassignedOrders_getUnassignedOrders_unassignedOrders as Order,
+} from '@/types/api';
 import styled from '@theme/styled';
 import MapFrame from '@components/MapFrame';
 import OrderLog from '@components/OrderLog';
 import Modal from '@components/Modal';
 import OrderModalItem from '@components/OrderModalItem';
-import { Location } from '@components/GoogleMap';
+import { Location } from '@reducers/.';
 import getUserLocation from '@utils/getUserLocation';
 import { GET_UNASSIGNED_ORDERS, UPDATE_ORDER_LIST, SUB_NEW_ORDER } from '@queries/order.queries';
+import { UPDATE_DRIVER_LOCATION } from '@queries/user.queries';
 import useModal from '@hooks/useModal';
-import {
-  GetUnassignedOrders,
-  GetUnassignedOrders_getUnassignedOrders_unassignedOrders as Order,
-} from '@/types/api';
+
 import { DRIVER } from '@utils/enums';
 
 const StyledOrderLogList = styled.section`
@@ -44,6 +46,7 @@ const Main: FC = () => {
   const [isModal, openModal, closeModal] = useModal();
   const [orderItem, setOrderItem] = useState<Order>();
   const [currentLocation, setCurrentLocation] = useState<Location>({ lat: 0, lng: 0 });
+  const [updateDriverLocation] = useCustomMutation<UpdateDriverLocation>(UPDATE_DRIVER_LOCATION);
   const { data } = useSubscription(UPDATE_ORDER_LIST, {
     onSubscriptionData: async () => {
       const newData = await callQuery();
@@ -62,6 +65,9 @@ const Main: FC = () => {
   const updateCurrentLocation = async () => {
     const curLocation = await getUserLocation();
     if (curLocation) {
+      updateDriverLocation({
+        variables: curLocation,
+      });
       setCurrentLocation(curLocation);
     }
   };

--- a/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
+++ b/server/src/api/user/updateDriverLocation/updateDriverLocation.resolvers.ts
@@ -1,6 +1,7 @@
 import { Resolvers } from '@type/api';
 import getActiveDriverOrder from '@services/order/getActiveDriverOrder';
 import updateDriverLocation from '@services/user/updateDriverLocation';
+import { UPDATE_ORDER_LIST } from '@api/order/updateOrderList/updateOrderList.resolvers';
 
 export const UPDATE_DRIVER_LOCATION = 'UPDATE_DRIVER_LOCATION';
 
@@ -16,6 +17,8 @@ const resolvers: Resolvers = {
       if (result === 'fail') {
         return { result, error };
       }
+
+      pubsub.publish(UPDATE_ORDER_LIST, { updateOrderList: { result: 'success' } });
 
       const { result: inquiryResult, order, error: inquiryError } = await getActiveDriverOrder(
         req.user?._id || '',


### PR DESCRIPTION
- [x] 드라이버위치 이동시마다 오더리스트(10km 이내) 갱신


### 첨부
![image](https://user-images.githubusercontent.com/49400477/100967937-bd65ab00-3573-11eb-89cf-d468e0e47a94.png)

A 위치에 오더생성후 B에서  A로 이동했을경우 A 위치의 오더가  리스트에 추가됩니다!
(A, B /10KM 이상차이나는 위치)
### 이슈
해당 작업 관련 이슈를 태그해주세요.
#155