### PR TITLE
[CY] 위치 이동 setTImeout -> 이동 감지 함수로 적용

### DIFF
--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -59,19 +59,15 @@ const GoToDestination: FC = () => {
   const updateInitLocation = useCallback((location: Location | void) => {
     if (location) {
       setCurrentLocation(location);
-      updateDriverLocationMutation({
-        variables: { lat: currentLocation.lat, lng: currentLocation.lng },
-      });
+      updateDriverLocationMutation({ variables: location });
     }
   }, []);
 
   const watchUpdateCurrentLocation = useCallback((location: Position) => {
-    setCurrentLocation({
-      lat: location.coords.latitude,
-      lng: location.coords.longitude,
-    });
+    const updateLocation = { lat: location.coords.latitude, lng: location.coords.longitude };
+    setCurrentLocation(updateLocation);
     updateDriverLocationMutation({
-      variables: { lat: location.coords.latitude, lng: location.coords.longitude },
+      variables: updateLocation,
     });
   }, []);
 

--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
@@ -12,7 +12,7 @@ import getUserLocation from '@utils/getUserLocation';
 import { DRIVER } from '@utils/enums';
 import { numberWithCommas } from '@utils/numberWithCommas';
 
-import { InitialState } from '@reducers/.';
+import { InitialState, Location } from '@reducers/.';
 
 const StyledGoToDestinationMenu = styled.div`
   display: flex;
@@ -56,22 +56,36 @@ const GoToDestination: FC = () => {
   const onClickChatRoom = () => {
     history.push(`/chatroom/${id}`);
   };
-  const updateCurrentLocation = async () => {
-    const currLocation = await getUserLocation();
-
-    if (currLocation) {
-      setTaxiFee((pre) => pre + DRIVER.INCRESE_TAXI_FEE);
+  const updateInitLocation = useCallback((location: Location | void) => {
+    if (location) {
+      setCurrentLocation(location);
       updateDriverLocationMutation({
-        variables: { lat: currLocation.lat, lng: currLocation.lng },
+        variables: { lat: currentLocation.lat, lng: currentLocation.lng },
       });
-      setCurrentLocation(currLocation);
     }
-  };
+  }, []);
+
+  const watchUpdateCurrentLocation = useCallback((location: Position) => {
+    setCurrentLocation({
+      lat: location.coords.latitude,
+      lng: location.coords.longitude,
+    });
+    updateDriverLocationMutation({
+      variables: { lat: location.coords.latitude, lng: location.coords.longitude },
+    });
+  }, []);
+
+  const updateTaxiFee = useCallback(() => {
+    setTaxiFee(taxiFee + DRIVER.INCRESE_TAXI_FEE);
+  }, [taxiFee]);
 
   useEffect(() => {
-    const updateCurrentLocationInterval = setInterval(updateCurrentLocation, 5000);
+    getUserLocation().then(updateInitLocation);
+    const watchLocation = navigator.geolocation.watchPosition(watchUpdateCurrentLocation);
+    const updateTaxiFeeInterval = setInterval(updateTaxiFee, 5000);
     return () => {
-      clearInterval(updateCurrentLocationInterval);
+      clearInterval(updateTaxiFeeInterval);
+      navigator.geolocation.clearWatch(watchLocation);
     };
   }, []);
 

--- a/client/src/routes/User/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/User/GoToDestination/GoToDestination.tsx
@@ -49,15 +49,18 @@ const GoToDestination: FC = () => {
     }
   }, []);
 
+  const watchUpdateCurrentLocation = useCallback((location: Position) => {
+    setCurrentLocation({
+      lat: location.coords.latitude,
+      lng: location.coords.longitude,
+    });
+  }, []);
+
   useEffect(() => {
     updateCurrentLocation();
-    const updateCurrentLocationInterval = setInterval(
-      updateCurrentLocation,
-      USER.USER_LOCATOIN_UPDATE_TIME,
-    );
-
+    const watchLocation = navigator.geolocation.watchPosition(watchUpdateCurrentLocation);
     return () => {
-      clearInterval(updateCurrentLocationInterval);
+      navigator.geolocation.clearWatch(watchLocation);
     };
   }, []);
 


### PR DESCRIPTION
### 작업 사항
- [x] 위치 이동 setTImeout -> 이동 감지 함수로 적용


### 요약
- 기존 사용자, 드라이버의 위치이동 감지를 setTimeout을 통해 n초마다 구혔했지만 `navigator.geolocation.watchPosition` 메서드를 사용해 위치가 변하는것을 감지하여 위치 업데이트 함수를 실행시켜줌

- 전체적으로 위치이동 속도 및 맵 로딩 속도 개선 (이제 위치 바꾸면 바로바로 적용됩니당)

### 첨부
![move](https://user-images.githubusercontent.com/49899406/100968543-dc187180-3574-11eb-95b3-c91211a6fefc.gif)
