### PR TITLE
[JE] 여러 active한 오더가 있을 경우 실시간 경로 공유 문제 해결

### DIFF
--- a/server/src/api/order/startDriving/startDriving.resolvers.ts
+++ b/server/src/api/order/startDriving/startDriving.resolvers.ts
@@ -1,5 +1,6 @@
 import { Resolvers } from '@type/api';
 
+import startDriving from '@services/order/startDriving';
 import {
   ORDER_CALL_STATUS,
   OrderCallStatus,
@@ -7,11 +8,15 @@ import {
 
 const resolvers: Resolvers = {
   Mutation: {
-    startDriving: (_, { orderId }, { pubsub }) => {
+    startDriving: async (_, { orderId }, { pubsub }) => {
+      const { result, error } = await startDriving(orderId);
+
+      if (result === 'fail') return { result, error };
+
       pubsub.publish(ORDER_CALL_STATUS, {
         subOrderCallStatus: { orderId, status: OrderCallStatus.STARTED_DRIVE },
       });
-      return { result: 'success' };
+      return { result };
     },
   },
 };

--- a/server/src/models/order.ts
+++ b/server/src/models/order.ts
@@ -14,6 +14,7 @@ const orderSchema = new Schema({
   destination: { type: locationSchema, required: true },
   status: { type: String, enum: ['close', 'active', 'waiting'], required: true },
   chat: [chatSchema],
+  createdAt: { type: Date, default: Date.now },
   startedAt: Schema.Types.Date,
   completedAt: Schema.Types.Date,
 });

--- a/server/src/services/order/createOrder.ts
+++ b/server/src/services/order/createOrder.ts
@@ -20,6 +20,7 @@ const createOrder = async ({ user, startingPoint, destination }: CreateOrderProp
       destination,
       payment: userPayment.get('payment'),
       status: 'waiting',
+      startedAt: new Date(),
     });
     return { result: 'success', orderId: createdOrder.get('_id'), createdOrder };
   } catch (err) {

--- a/server/src/services/order/createOrder.ts
+++ b/server/src/services/order/createOrder.ts
@@ -20,7 +20,6 @@ const createOrder = async ({ user, startingPoint, destination }: CreateOrderProp
       destination,
       payment: userPayment.get('payment'),
       status: 'waiting',
-      startedAt: new Date(),
     });
     return { result: 'success', orderId: createdOrder.get('_id'), createdOrder };
   } catch (err) {

--- a/server/src/services/order/getActiveDriverOrder.ts
+++ b/server/src/services/order/getActiveDriverOrder.ts
@@ -4,7 +4,7 @@ import { Order as OrderType } from '@type/api';
 const getActiveDriverOrder = async (driverId: string) => {
   try {
     const order = (await Order.findOne({ driver: driverId, status: 'active' })
-      .sort({ startedAt: -1 })
+      .sort({ createdAt: -1 })
       .limit(1)) as OrderType | null;
 
     return { result: 'success', order };

--- a/server/src/services/order/getActiveDriverOrder.ts
+++ b/server/src/services/order/getActiveDriverOrder.ts
@@ -3,10 +3,10 @@ import { Order as OrderType } from '@type/api';
 
 const getActiveDriverOrder = async (driverId: string) => {
   try {
-    const order = (await Order.findOne({
-      driver: driverId,
-      status: 'active',
-    })) as OrderType | null;
+    const order = (await Order.findOne({ driver: driverId, status: 'active' })
+      .sort({ startedAt: -1 })
+      .limit(1)) as OrderType | null;
+
     return { result: 'success', order };
   } catch (err) {
     return { result: 'fail', error: err.message };

--- a/server/src/services/order/startDriving.ts
+++ b/server/src/services/order/startDriving.ts
@@ -1,0 +1,13 @@
+import Order from '@models/order';
+
+const startDriving = async (orderId: string) => {
+  try {
+    const result = await Order.findByIdAndUpdate(orderId, { startedAt: new Date() });
+
+    return { result: 'success' };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default startDriving;


### PR DESCRIPTION
### 작업 사항
- [x] active한 오더가 여러개 있을 경우 가장 최근 오더를 불러오도록 수정

### 요약
- 기존에는 드라이버의 active한 오더를 가져오도록 구현되어 있었는데 추가적으로 그 중에서 가장 최근에 생성된 오더를 불러오도록 조건을 추가해서 수정했습니다.
- 에러가 발생하는 부분이 운행을 시작하기 전, 드라이버가 출발지까지 오는 경로를 실시간으로 공유하는 곳.
- 따라서 운행시작시간이 아닌 오더 생성시간을 기준으로 비교해서 불러왔습니다.

### 첨부

### 이슈
#153 