### PR TITLE
[CY] 운행 완료 API 기능 구현

### DIFF
--- a/server/src/api/order/completeOrder/completeOrder.graphql
+++ b/server/src/api/order/completeOrder/completeOrder.graphql
@@ -1,0 +1,8 @@
+type CompleteOrderResponse {
+    result: String!
+    error: String
+}
+
+type Mutation {
+    completeOrder(orderId: String!): CompleteOrderResponse! @auth
+}

--- a/server/src/api/order/completeOrder/completeOrder.graphql
+++ b/server/src/api/order/completeOrder/completeOrder.graphql
@@ -4,5 +4,5 @@ type CompleteOrderResponse {
 }
 
 type Mutation {
-    completeOrder(orderId: String!): CompleteOrderResponse! @auth
+    completeOrder(orderId: String!, amount: Int!): CompleteOrderResponse! @auth
 }

--- a/server/src/api/order/completeOrder/completeOrder.resolvers.ts
+++ b/server/src/api/order/completeOrder/completeOrder.resolvers.ts
@@ -1,0 +1,26 @@
+import { Resolvers } from '@type/api';
+
+import completeOrder from '@services/order/completeOrder';
+import {
+  ORDER_CALL_STATUS,
+  OrderCallStatus,
+} from '@api/order/subOrderCallStatus/subOrderCallStatus.resolvers';
+
+const resolvers: Resolvers = {
+  Mutation: {
+    completeOrder: async (_, { orderId }, { pubsub }) => {
+      const { result, error } = await completeOrder(orderId);
+
+      if (result === 'fail' || error) {
+        return { result, error };
+      }
+      pubsub.publish(ORDER_CALL_STATUS, {
+        subOrderCallStatus: { orderId, status: OrderCallStatus.COMPLETED_DRIVE },
+      });
+
+      return { result };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/api/order/completeOrder/completeOrder.resolvers.ts
+++ b/server/src/api/order/completeOrder/completeOrder.resolvers.ts
@@ -8,8 +8,8 @@ import {
 
 const resolvers: Resolvers = {
   Mutation: {
-    completeOrder: async (_, { orderId }, { pubsub }) => {
-      const { result, error } = await completeOrder(orderId);
+    completeOrder: async (_, { orderId, amount }, { pubsub }) => {
+      const { result, error } = await completeOrder(orderId, amount);
 
       if (result === 'fail' || error) {
         return { result, error };

--- a/server/src/services/order/completeOrder.ts
+++ b/server/src/services/order/completeOrder.ts
@@ -1,0 +1,15 @@
+import Order from '@models/order';
+
+const completeOrder = async (orderId: string) => {
+  try {
+    await Order.findByIdAndUpdate(orderId, {
+      status: 'close',
+      completedAt: Date.now(),
+    });
+    return { result: 'success' };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default completeOrder;

--- a/server/src/services/order/completeOrder.ts
+++ b/server/src/services/order/completeOrder.ts
@@ -1,9 +1,10 @@
 import Order from '@models/order';
 
-const completeOrder = async (orderId: string) => {
+const completeOrder = async (orderId: string, amount: number) => {
   try {
     await Order.findByIdAndUpdate(orderId, {
       status: 'close',
+      amount,
       completedAt: Date.now(),
     });
     return { result: 'success' };


### PR DESCRIPTION
### 작업 사항
- [x] 운행 완료 API 기능 구현
- [x] 운행 완료시 오더의 callStatus를 구독하고 있는 subscription에게 publish


### 요약
운행 완료 API 기능 구현


### 첨부
![image](https://user-images.githubusercontent.com/49899406/100972368-04f03500-357c-11eb-9352-fd02a009228c.png)
![image](https://user-images.githubusercontent.com/49899406/100972345-fb66cd00-357b-11eb-8c0e-4e4d30f1ddea.png)


### 이슈
#158 