### PR TITLE
[HJ] 드라이버 오더수락시 사용자화면에서 (출발지, 목적지) 표시

### DIFF
--- a/client/src/queries/user.queries.ts
+++ b/client/src/queries/user.queries.ts
@@ -25,6 +25,19 @@ export const GET_USER_WITH_ORDER = gql`
   }
 `;
 
+export const GET_DRIVER_LOCATION = gql`
+  query getDriverLocation($orderId: String!) {
+    getDriverLocation(orderId: $orderId) {
+      result
+      driverLocation {
+        lat
+        lng
+      }
+      error
+    }
+  }
+`;
+
 export const SIGNIN = gql`
   mutation Signin($email: String!, $password: String!, $loginType: String!) {
     signin(email: $email, password: $password, loginType: $loginType) {

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -55,15 +55,6 @@ const GoToOrigin: FC = () => {
   });
   const history = useHistory();
 
-  const updateInitLocation = useCallback((location: Location | void) => {
-    if (location) {
-      setCurrentLocation(location);
-      updateDriverLocationMutation({
-        variables: { lat: currentLocation.lat, lng: currentLocation.lng },
-      });
-    }
-  }, []);
-
   const watchUpdateCurrentLocation = useCallback((location: Position) => {
     setCurrentLocation({
       lat: location.coords.latitude,
@@ -79,7 +70,6 @@ const GoToOrigin: FC = () => {
   }, [id]);
 
   useEffect(() => {
-    getUserLocation().then(updateInitLocation);
     const watchLocation = navigator.geolocation.watchPosition(watchUpdateCurrentLocation);
     return () => {
       navigator.geolocation.clearWatch(watchLocation);

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -60,7 +60,7 @@ const WaitingDriver = () => {
   useCustomQuery<getDriverLocation>(GET_DRIVER_LOCATION, {
     variables: { orderId: id },
     onCompleted: (data) => {
-      if (data && data.getDriverLocation && data.getDriverLocation.driverLocation) {
+      if (data.getDriverLocation.driverLocation) {
         setDriverLocation(data.getDriverLocation.driverLocation);
       }
     },

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Button } from 'antd-mobile';
 import styled from '@theme/styled';
 import { useSubscription } from '@apollo/react-hooks';
@@ -7,12 +7,14 @@ import { useHistory } from 'react-router-dom';
 
 import MapFrame from '@components/MapFrame';
 import { GET_ORDER_CAR_INFO, SUB_ORDER_CALL_STATUS } from '@queries/order.queries';
-import { SUB_DRIVER_LOCATION } from '@queries/user.queries';
+import { SUB_DRIVER_LOCATION, GET_DRIVER_LOCATION } from '@queries/user.queries';
 import {
   SubDriverLocation,
   GetOrderCarInfo,
   CarInfo as CarInfoType,
   SubOrderCallStatus,
+  getDriverLocation,
+  getDriverLocation_getDriverLocation_driverLocation as driverLocation,
 } from '@/types/api';
 import { OrderCallStatus } from '@/types/orderCallStatus';
 import { useCustomQuery } from '@hooks/useApollo';
@@ -54,6 +56,15 @@ const WaitingDriver = () => {
   const [carInfo, setCarInfo] = useState({ carNumber: '', carType: 'small' } as CarInfoType);
   const { id } = useSelector(({ order }: InitialState) => order || {});
   const { origin: userOrigin } = useSelector(({ order }: InitialState) => order.location);
+
+  useCustomQuery<getDriverLocation>(GET_DRIVER_LOCATION, {
+    variables: { orderId: id },
+    onCompleted: (data) => {
+      if (data && data.getDriverLocation && data.getDriverLocation.driverLocation) {
+        setDriverLocation(data.getDriverLocation.driverLocation);
+      }
+    },
+  });
 
   useCustomQuery<GetOrderCarInfo>(GET_ORDER_CAR_INFO, {
     variables: { orderId: id },

--- a/server/src/api/user/getDriverLocation/getDriverLocation.graphql
+++ b/server/src/api/user/getDriverLocation/getDriverLocation.graphql
@@ -1,0 +1,14 @@
+type DriverLocation {
+    lat: Float!
+    lng: Float!
+}
+
+type getDriverLocationResponse {
+    result: String!
+    driverLocation: DriverLocation
+    error: String
+}
+
+type Query {
+    getDriverLocation(orderId: String!): getDriverLocationResponse!
+}

--- a/server/src/api/user/getDriverLocation/getDriverLocation.resolvers.ts
+++ b/server/src/api/user/getDriverLocation/getDriverLocation.resolvers.ts
@@ -1,0 +1,21 @@
+import { Resolvers } from '@type/api';
+import getDriverLocation from '@services/user/getDriverLocation';
+import { Message } from '@util/server-message';
+
+const resolvers: Resolvers = {
+  Query: {
+    getDriverLocation: async (_, { orderId }) => {
+      const { result, error, driverLocation } = await getDriverLocation(orderId);
+      if (!driverLocation) {
+        return { result, error: Message.OrderNotFound };
+      }
+      if (result === 'fail') {
+        return { result, error };
+      }
+
+      return { result: 'true', driverLocation };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/services/user/getDriverLocation.ts
+++ b/server/src/services/user/getDriverLocation.ts
@@ -1,0 +1,21 @@
+import Order from '@models/order';
+
+const getDriverLocation = async (orderId: string) => {
+  try {
+    const order = await Order.findOne({ _id: orderId }).populate('driver');
+    const LocationCoordinates = order?.get('driver.location.coordinates');
+
+    const driverLocation = {
+      lat: LocationCoordinates[0],
+      lng: LocationCoordinates[1],
+    };
+    if (!order) {
+      return { result: 'fail' };
+    }
+    return { result: 'success', driverLocation };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default getDriverLocation;

--- a/server/src/services/user/getDriverLocation.ts
+++ b/server/src/services/user/getDriverLocation.ts
@@ -5,13 +5,15 @@ const getDriverLocation = async (orderId: string) => {
     const order = await Order.findOne({ _id: orderId }).populate('driver');
     const LocationCoordinates = order?.get('driver.location.coordinates');
 
+    if (!order) {
+      return { result: 'fail' };
+    }
+
     const driverLocation = {
       lat: LocationCoordinates[0],
       lng: LocationCoordinates[1],
     };
-    if (!order) {
-      return { result: 'fail' };
-    }
+
     return { result: 'success', driverLocation };
   } catch (err) {
     return { result: 'fail', error: err.message };


### PR DESCRIPTION
### 작업 사항
- [x] 드라이버 위치가져오는 API 작성
- [x] 드라이버 오더 수락시 사용자 화면에서 드라이버위치(origin) / 오더 출발지(destination) 표시


### 요약
- 드라이버화면 
  드라이버 오더 수락시 화면이동 => 초기 드라이버 위치 갱신 뮤테이션 => 사용자화면에서 드라이버 위치 구독 
- 사용자화면
  드라이버 오더승인 확인 알람 후 페이지 이동을 하므로 드라이버의 초기위치를 구독하지못해 초기 경로 설정 못하는 문제발생
  사용자 화면이동시 드라이버의 위치 받아와 초기경로 설정

- 사용자 화면에서 초기에 드라이버 차량정보 받아오는 API 와 합치면 좋을것같습니다.. 발견하지 못했어요 ..
![image](https://user-images.githubusercontent.com/49400477/101097616-d4a0a900-3604-11eb-9de3-4cf4d0a78ec5.png)


### 첨부

![캡처 1](https://user-images.githubusercontent.com/49400477/101096882-92c33300-3603-11eb-86e2-729d46ec5373.PNG)
![image](https://user-images.githubusercontent.com/49400477/101096860-8939cb00-3603-11eb-80d0-1b04066990a6.png)




### 이슈
#164 