### PR TITLE
[JE] 이용 기록 확인

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import DriverGoToDestination from '@routes/Driver/GoToDestination';
 import Signup from '@routes/Signup';
 import SearchDriver from '@routes/User/SearchDriver';
 import UserGoToDestination from '@routes/User/GoToDestination';
+import OrderHistory from '@routes/OrderHistory';
 
 import theme from '@theme/.';
 import GlobalStyle from '@theme/global';
@@ -52,6 +53,7 @@ const App: FC = () => (
             <Route exact path="/user/searchDriver" component={auth(SearchDriver, 'user')} />
             <Route exact path="/signin" component={SignIn} />
             <Route exact path="/signup" component={Signup} />
+            <Route exact path="/orderHistory" component={auth(OrderHistory)} />
             <Route exact path="/chatroom/:chatId" component={auth(ChatRoom)} />
           </Switch>
         </BrowserRouter>

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import useToggle from '@hooks/useToggle';
+import { useHistory } from 'react-router-dom';
 
 import styled from '@theme/styled';
 import MenuSVG from '@images/menuSVG.tsx';
@@ -37,18 +38,27 @@ const StyledHeaderWithMenu = styled.header<StyledProps>`
     top: 3rem;
     left: 0;
     visibility: ${(props) => (props.isMenuOpen ? 'visible' : 'hidden')};
-    width: ${(props) => (props.isMenuOpen ? '100%' : '0')};
+    width: ${(props) => (props.isMenuOpen ? '50%' : '0')};
     height: calc(100vh - 3rem);
     z-index: 1;
     padding: 1rem 1rem;
     background-color: #ffffff;
     border-right: 1px solid ${({ theme }) => theme.PRIMARY};
     transition: 0.5s;
+
+    & button {
+      font-size: 1.2rem;
+    }
   }
 `;
 
 const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
+  const history = useHistory();
   const [menu, toggleMenu] = useToggle(false);
+
+  const onClickCompletedOrders = () => {
+    history.push('/orderHistory');
+  };
 
   return (
     <StyledHeaderWithMenu className={className} isMenuOpen={menu}>
@@ -57,7 +67,9 @@ const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
       </button>
       <menu>
         <ul>
-          <li>마이페이지</li>
+          <li>
+            <button onClick={onClickCompletedOrders}>이용 기록</button>
+          </li>
         </ul>
       </menu>
     </StyledHeaderWithMenu>

--- a/client/src/components/OrderHistoryList/Log.tsx
+++ b/client/src/components/OrderHistoryList/Log.tsx
@@ -13,7 +13,7 @@ const StyledLog = styled.div`
     display: flex;
     margin-bottom: 0.4rem;
 
-    & div:nth-of-type(1) {
+    & .completed-order-info-title {
       margin-right: 2.3rem;
     }
   }
@@ -21,7 +21,7 @@ const StyledLog = styled.div`
   & .last-completed-order-info {
     display: flex;
 
-    & div:nth-of-type(1) {
+    & .completed-order-info-title {
       margin-right: 1.5rem;
     }
   }
@@ -35,16 +35,19 @@ const Log: FC<LogProps> = ({ order }) => {
   return (
     <StyledLog>
       <div className="completed-order-info">
-        <div>출발지</div> <div>{order.startingPoint.address}</div>
+        <div className="completed-order-info-title">출발지</div>{' '}
+        <div>{order.startingPoint.address}</div>
       </div>
       <div className="completed-order-info">
-        <div>도착지</div> <div>{order.destination.address}</div>
+        <div className="completed-order-info-title">도착지</div>{' '}
+        <div>{order.destination.address}</div>
       </div>
       <div className="completed-order-info">
-        <div>결제비</div> <div>{order.amount}원</div>
+        <div className="completed-order-info-title">결제비</div> <div>{order.amount}원</div>
       </div>
       <div className="last-completed-order-info">
-        <div>운행시간</div> <div>{calcDriveTime(order.startedAt, order.completedAt)}</div>
+        <div className="completed-order-info-title">운행시간</div>{' '}
+        <div>{calcDriveTime(order.startedAt, order.completedAt)}</div>
       </div>
     </StyledLog>
   );

--- a/client/src/components/OrderHistoryList/Log.tsx
+++ b/client/src/components/OrderHistoryList/Log.tsx
@@ -1,7 +1,53 @@
-import React from 'react';
+import React, { FC } from 'react';
+import { GetCompletedOrders_getCompletedOrders_completedOrders as CompletedOrders } from '@/types/api';
+import styled from '@theme/styled';
+import calcDriveTime from '@utils/calcDriveTime';
 
-const Log = () => {
-  return <>LOG</>;
+const StyledLog = styled.div`
+  border: 1px solid lightgray;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+  padding: 0.5rem;
+
+  & .completed-order-info {
+    display: flex;
+    margin-bottom: 0.4rem;
+
+    & div:nth-of-type(1) {
+      margin-right: 2.3rem;
+    }
+  }
+
+  & .last-completed-order-info {
+    display: flex;
+
+    & div:nth-of-type(1) {
+      margin-right: 1.5rem;
+    }
+  }
+`;
+
+interface LogProps {
+  order: CompletedOrders;
+}
+
+const Log: FC<LogProps> = ({ order }) => {
+  return (
+    <StyledLog>
+      <div className="completed-order-info">
+        <div>출발지</div> <div>{order.startingPoint.address}</div>
+      </div>
+      <div className="completed-order-info">
+        <div>도착지</div> <div>{order.destination.address}</div>
+      </div>
+      <div className="completed-order-info">
+        <div>결제비</div> <div>{order.amount}원</div>
+      </div>
+      <div className="last-completed-order-info">
+        <div>운행시간</div> <div>{calcDriveTime(order.startedAt, order.completedAt)}</div>
+      </div>
+    </StyledLog>
+  );
 };
 
 export default Log;

--- a/client/src/components/OrderHistoryList/Log.tsx
+++ b/client/src/components/OrderHistoryList/Log.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Log = () => {
+  return <>LOG</>;
+};
+
+export default Log;

--- a/client/src/components/OrderHistoryList/OrderHistoryList.tsx
+++ b/client/src/components/OrderHistoryList/OrderHistoryList.tsx
@@ -1,8 +1,25 @@
-import React from 'react';
+import React, { FC } from 'react';
+import { GetCompletedOrders_getCompletedOrders_completedOrders as CompletedOrders } from '@/types/api';
+import styled from '@theme/styled';
 import Log from './Log';
 
-const OrderHistoryList = () => {
-  return <>LIST</>;
+const StyledOrderHistoryList = styled.div`
+  padding: 0 1rem;
+  overflow-y: scroll;
+  border: 1px solid blue;
+  height: calc(100% - 3rem);
+`;
+
+interface OrderHistoryListProps {
+  orders: CompletedOrders[] | undefined | null;
+}
+
+const OrderHistoryList: FC<OrderHistoryListProps> = ({ orders }) => {
+  return (
+    <StyledOrderHistoryList>
+      {orders && orders.length !== 0 ? orders.map((order) => <Log order={order} />) : <>No Order</>}
+    </StyledOrderHistoryList>
+  );
 };
 
 export default OrderHistoryList;

--- a/client/src/components/OrderHistoryList/OrderHistoryList.tsx
+++ b/client/src/components/OrderHistoryList/OrderHistoryList.tsx
@@ -16,7 +16,11 @@ interface OrderHistoryListProps {
 const OrderHistoryList: FC<OrderHistoryListProps> = ({ orders }) => {
   return (
     <StyledOrderHistoryList>
-      {orders && orders.length !== 0 ? orders.map((order) => <Log order={order} />) : <>No Order</>}
+      {orders && orders.length !== 0 ? (
+        orders.map((order) => <Log order={order} key={`completed_order_${order._id}`} />)
+      ) : (
+        <>No Order</>
+      )}
     </StyledOrderHistoryList>
   );
 };

--- a/client/src/components/OrderHistoryList/OrderHistoryList.tsx
+++ b/client/src/components/OrderHistoryList/OrderHistoryList.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Log from './Log';
+
+const OrderHistoryList = () => {
+  return <>LIST</>;
+};
+
+export default OrderHistoryList;

--- a/client/src/components/OrderHistoryList/OrderHistoryList.tsx
+++ b/client/src/components/OrderHistoryList/OrderHistoryList.tsx
@@ -6,7 +6,6 @@ import Log from './Log';
 const StyledOrderHistoryList = styled.div`
   padding: 0 1rem;
   overflow-y: scroll;
-  border: 1px solid blue;
   height: calc(100% - 3rem);
 `;
 

--- a/client/src/components/OrderHistoryList/index.ts
+++ b/client/src/components/OrderHistoryList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderHistoryList';

--- a/client/src/queries/order.queries.ts
+++ b/client/src/queries/order.queries.ts
@@ -158,3 +158,27 @@ export const COMPLETE_ORDER = gql`
     }
   }
 `;
+
+export const GET_COMPLETED_ORDER = gql`
+  query GetCompletedOrders {
+    getCompletedOrders {
+      result
+      completedOrders {
+        _id
+        startingPoint {
+          coordinates
+          address
+        }
+        destination {
+          coordinates
+          address
+        }
+        amount
+        startedAt
+        completedAt
+        driver
+      }
+      error
+    }
+  }
+`;

--- a/client/src/routes/OrderHistory/OrderHistory.tsx
+++ b/client/src/routes/OrderHistory/OrderHistory.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import OrderHistoryList from '@/components/OrderHistoryList';
+import { GetCompletedOrders } from '@/types/api';
+import { GET_COMPLETED_ORDER } from '@queries/order.queries';
+import { useCustomQuery } from '@hooks/useApollo';
+
+const OrderHistory = () => {
+  const { data: orders } = useCustomQuery<GetCompletedOrders>(GET_COMPLETED_ORDER);
+  console.log(orders);
+
+  return <OrderHistoryList />;
+};
+
+export default OrderHistory;

--- a/client/src/routes/OrderHistory/OrderHistory.tsx
+++ b/client/src/routes/OrderHistory/OrderHistory.tsx
@@ -1,15 +1,30 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 import OrderHistoryList from '@/components/OrderHistoryList';
-import { GetCompletedOrders } from '@/types/api';
+import {
+  GetCompletedOrders,
+  GetCompletedOrders_getCompletedOrders_completedOrders as CompletedOrders,
+} from '@/types/api';
 import { GET_COMPLETED_ORDER } from '@queries/order.queries';
 import { useCustomQuery } from '@hooks/useApollo';
+import HeaderWithBack from '@components/HeaderWithBack';
 
 const OrderHistory = () => {
-  const { data: orders } = useCustomQuery<GetCompletedOrders>(GET_COMPLETED_ORDER);
-  console.log(orders);
+  const history = useHistory();
+  const { data } = useCustomQuery<GetCompletedOrders>(GET_COMPLETED_ORDER);
+  const completedOrders = data?.getCompletedOrders.completedOrders;
 
-  return <OrderHistoryList />;
+  const onClickBackButton = () => {
+    history.goBack();
+  };
+
+  return (
+    <>
+      <HeaderWithBack onClick={onClickBackButton} className="green-header" />
+      <OrderHistoryList orders={completedOrders} />
+    </>
+  );
 };
 
 export default OrderHistory;

--- a/client/src/routes/OrderHistory/index.ts
+++ b/client/src/routes/OrderHistory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OrderHistory';

--- a/server/src/api/order/getCompletedOrder/getCompletedOrder.graphql
+++ b/server/src/api/order/getCompletedOrder/getCompletedOrder.graphql
@@ -1,0 +1,9 @@
+type GetCompletedOrdersResponse {
+  result: String!
+  completedOrders: [Order!]
+  error: String
+}
+
+type Query {
+  getCompletedOrders: GetCompletedOrdersResponse! @auth
+}

--- a/server/src/api/order/getCompletedOrder/getCompletedOrder.resolvers.ts
+++ b/server/src/api/order/getCompletedOrder/getCompletedOrder.resolvers.ts
@@ -1,0 +1,21 @@
+import { Resolvers } from '@type/api';
+import getCompletedOrders from '@services/order/getCompletedOrders';
+
+const resolvers: Resolvers = {
+  Query: {
+    getCompletedOrders: async (_, __, { req }) => {
+      const { result, completedOrders, error } = await getCompletedOrders({
+        userId: req.user?._id || '',
+        userType: req.user?.type,
+      });
+
+      if (!completedOrders && (result === 'fail' || error)) {
+        return { result, error };
+      }
+
+      return { result, completedOrders };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/services/order/getCompletedOrders.ts
+++ b/server/src/services/order/getCompletedOrders.ts
@@ -1,0 +1,33 @@
+import Order from '@models/order';
+import { Order as OrderType } from '@type/api';
+import { loginType, LoginType } from '@models/user';
+
+interface GetCompletedOrdersProps {
+  userId: string;
+  userType?: LoginType;
+}
+
+interface Query {
+  user?: string;
+  driver?: string;
+  status: string;
+}
+
+const getCompletedOrders = async ({ userId, userType }: GetCompletedOrdersProps) => {
+  try {
+    const query: Query = {
+      status: 'close',
+    };
+
+    if (userType === loginType.user) query.user = userId;
+    else if (userType === loginType.driver) query.driver = userId;
+
+    const completedOrders = ((await Order.find(query)) as unknown) as OrderType[];
+
+    return { result: 'success', completedOrders };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default getCompletedOrders;


### PR DESCRIPTION
### 작업 사항
- [x] 운행이 종료된 오더들을 확인
- [x] 메뉴의 '이용 종료'버튼과 페이지 연결


### 요약
운행이 종료된 오더들을 리스트 형식으로 볼 수 있는 페이지를 구현했습니다.


### 첨부
![image](https://user-images.githubusercontent.com/43084680/101235881-a8258380-370f-11eb-98fe-2e919d68971e.png)


### 이슈
#146 