### PR TITLE
[HJ] 택시 요금 업데이트 안되는 현상 해결.

### DIFF
--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -119,7 +119,7 @@ const GoToDestination: FC = () => {
   }, []);
 
   const updateTaxiFee = useCallback(() => {
-    setTaxiFee(taxiFee + DRIVER.INCRESE_TAXI_FEE);
+    setTaxiFee((pre) => pre + DRIVER.INCRESE_TAXI_FEE);
   }, [taxiFee]);
 
   useEffect(() => {


### PR DESCRIPTION

### 작업 사항
- [x] 택시요금 업데이트 안되는 현상 해결


### 요약
- useEffect 실행후  setInterval 함수에 클로저가 첫렌더링시 taxiFee 를 참조하기때문에  계속해서 3100 원에서 멈춰있었습니다.
- setState(pre => pre + 1) 형식으로 변경하여 항상 새로운 상태를 읽을 수 있게 변경했습니다.

### 이슈
#166