### PR TITLE
[JH] 채팅방 업데이트 이슈 해결, 채팅 생성 시 createdAt, writer 속성 서버에서 넣어주도록 변경

### DIFF
--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -5,7 +5,6 @@ import styled from '@theme/styled';
 interface Props {
   writer?: string;
   content?: string;
-  createdAt?: string | null;
   type: string;
 }
 
@@ -28,7 +27,7 @@ const StyledChatLogWrapper = styled.div<Type>`
   }
 `;
 
-const ChatLog: FC<Props> = ({ content, createdAt, writer, type }) => {
+const ChatLog: FC<Props> = ({ content, writer, type }) => {
   return (
     <StyledChatLogWrapper type={type} writer={writer}>
       <span className="chat-content">{content}</span>

--- a/client/src/components/EstimatedTime/EstimatedTime.tsx
+++ b/client/src/components/EstimatedTime/EstimatedTime.tsx
@@ -33,8 +33,14 @@ const EstimatedTime: FC<Props> = ({ directions }) => {
     <>
       {origin && destination && (
         <StyledEstimatedTime>
-          <span className="estimated-time">소요 시간: {estimatedTime?.text}</span>
-          <span className="estimated-distance">이동 거리: {estimatedDistance?.text}</span>
+          <span className="estimated-time">
+            {'소요 시간: '}
+            {estimatedTime?.text}
+          </span>
+          <span className="estimated-distance">
+            {'이동 거리: '}
+            {estimatedDistance?.text}
+          </span>
         </StyledEstimatedTime>
       )}
     </>

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import useToggle from '@hooks/useToggle';
 import { useHistory } from 'react-router-dom';
+import { Button } from 'antd-mobile';
 
 import styled from '@theme/styled';
 import MenuSVG from '@images/menuSVG.tsx';
@@ -46,7 +47,8 @@ const StyledHeaderWithMenu = styled.header<StyledProps>`
     border-right: 1px solid ${({ theme }) => theme.PRIMARY};
     transition: 0.5s;
 
-    & button {
+    & .am-button {
+      position: inherit;
       font-size: 1.2rem;
     }
   }
@@ -68,7 +70,7 @@ const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
       <menu>
         <ul>
           <li>
-            <button onClick={onClickCompletedOrders}>이용 기록</button>
+            <Button onClick={onClickCompletedOrders}>이용 기록</Button>
           </li>
         </ul>
       </menu>

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import useToggle from '@hooks/useToggle';
 import { useHistory } from 'react-router-dom';
-import { Button } from 'antd-mobile';
 
 import styled from '@theme/styled';
 import MenuSVG from '@images/menuSVG.tsx';
@@ -70,7 +69,9 @@ const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
       <menu>
         <ul>
           <li>
-            <Button onClick={onClickCompletedOrders}>이용 기록</Button>
+            <button type="button" onClick={onClickCompletedOrders}>
+              이용 기록
+            </button>
           </li>
         </ul>
       </menu>

--- a/client/src/queries/chat/createChat.queries.ts
+++ b/client/src/queries/chat/createChat.queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 const CREATE_CHAT = gql`
-  mutation CreateChat($content: String!, $writer: String!, $createdAt: String!, $chatId: String!) {
-    createChat(content: $content, writer: $writer, createdAt: $createdAt, chatId: $chatId) {
+  mutation CreateChat($content: String!, $chatId: String!) {
+    createChat(content: $content, chatId: $chatId) {
       result
       error
     }

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -45,7 +45,7 @@ const ChatRoom: FC = () => {
 
   const onClickSubmitButton = () => {
     CreateChat({
-      variables: { chatId, writer: userId, createdAt: '2020-12-01', content: chatContent },
+      variables: { chatId, content: chatContent },
     });
     setChatContent('');
   };
@@ -53,7 +53,7 @@ const ChatRoom: FC = () => {
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     CreateChat({
-      variables: { chatId, writer: userId, createdAt: '2020-12-01', content: chatContent },
+      variables: { chatId, content: chatContent },
     });
     setChatContent('');
   };
@@ -84,7 +84,12 @@ const ChatRoom: FC = () => {
         {chatList &&
           chatList?.length !== 0 &&
           chatList.map((item) => (
-            <ChatLog key={`chat_${item?.createdAt}`} {...item} type={userId} />
+            <ChatLog
+              key={`chat_${item}`}
+              content={item?.content}
+              writer={item?.writer}
+              type={userId}
+            />
           ))}
       </StyledChatMain>
       <ChatInput

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { useSubscription } from '@apollo/client';
 
 import HeaderWithBack from '@components/HeaderWithBack';
 import ChatLog from '@components/ChatLog';
@@ -8,7 +9,7 @@ import ChatInput from '@components/ChatInput';
 import styled from '@theme/styled';
 import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 import { CREATE_CHAT, GET_CHAT, SUB_CHAT } from '@/queries/chat';
-import { GetChat, GetChat_getChat_chats as ChatType, SubChat } from '@/types/api';
+import { GetChat, GetChat_getChat_chats as ChatType } from '@/types/api';
 import useChange from '@/hooks/useChange';
 import { InitialState, User } from '@reducers/.';
 
@@ -29,15 +30,24 @@ const StyledChatMain = styled.div`
 
 const ChatRoom: FC = () => {
   const history = useHistory();
-  const chatRef = useRef<HTMLDivElement>(null);
   const { chatId } = useParams<ChatID>();
+  const chatRef = useRef<HTMLDivElement>(null);
   const { _id: userId } = useSelector((state: InitialState) => state?.user || ({} as User));
-  const { data: chatData, subscribeToMore } = useCustomQuery<GetChat>(GET_CHAT, {
+  const [chatContent, setChatContent, onChangeChatContent] = useChange('');
+  const [chats, setChats] = useState<(ChatType | null)[]>([]);
+  const { data: chatData, loading } = useCustomQuery<GetChat>(GET_CHAT, {
     variables: { chatId },
   });
   const [CreateChat] = useCustomMutation(CREATE_CHAT);
-  const [chatContent, setChatContent, onChangeChatContent] = useChange('');
-  const chatList = chatData?.getChat.chats;
+  const { data } = useSubscription(SUB_CHAT, {
+    variables: {
+      chatId,
+    },
+    onSubscriptionData: ({ subscriptionData }) => {
+      const { chat } = subscriptionData.data.subChat;
+      setChats([...chats, chat]);
+    },
+  });
 
   const onClickBackButton = () => {
     history.goBack();
@@ -59,31 +69,23 @@ const ChatRoom: FC = () => {
   };
 
   useEffect(() => {
-    subscribeToMore({
-      document: SUB_CHAT,
-      variables: { chatId },
-      updateQuery: (prev, { subscriptionData }) => {
-        if (!subscriptionData.data) return prev;
-
-        const { subChat } = (subscriptionData.data as unknown) as SubChat;
-        const newChat = subChat.chat as ChatType;
-
-        return { ...prev, getChat: { ...prev.getChat, chats: [...prev.getChat.chats, newChat] } };
-      },
-    });
-  }, []);
+    chatRef.current!.scrollTop = chatRef.current!.scrollHeight;
+  }, [chats]);
 
   useEffect(() => {
-    chatRef.current!.scrollTop = chatRef.current!.scrollHeight;
-  }, [chatList]);
+    if (!loading) {
+      const chats = chatData?.getChat.chats as [ChatType];
+      setChats(chats);
+    }
+  }, [loading]);
 
   return (
     <StyledChatRoom>
       <HeaderWithBack onClick={onClickBackButton} className="green-header" />
       <StyledChatMain ref={chatRef}>
-        {chatList &&
-          chatList?.length !== 0 &&
-          chatList.map((item) => (
+        {chats &&
+          chats?.length !== 0 &&
+          chats.map((item) => (
             <ChatLog
               key={`chat_${item}`}
               content={item?.content}

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { FC, useEffect, useRef, useState, useCallback } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useSubscription } from '@apollo/client';
@@ -54,9 +54,9 @@ const ChatRoom: FC = () => {
     },
   });
 
-  const onClickBackButton = () => {
+  const onClickBackButton = useCallback(() => {
     history.goBack();
-  };
+  }, []);
 
   const onClickSubmitButton = () => {
     CreateChat({

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -39,7 +39,9 @@ const ChatRoom: FC = () => {
   const { data: chatData } = useCustomQuery<GetChat>(GET_CHAT, {
     variables: { chatId },
     onCompleted: (data) => {
-      setChats(data.getChat.chats);
+      if (data.getChat.result === 'success') {
+        setChats(data.getChat.chats);
+      }
     },
   });
   const { data } = useSubscription(SUB_CHAT, {

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -35,10 +35,13 @@ const ChatRoom: FC = () => {
   const { _id: userId } = useSelector((state: InitialState) => state?.user || ({} as User));
   const [chatContent, setChatContent, onChangeChatContent] = useChange('');
   const [chats, setChats] = useState<(ChatType | null)[]>([]);
-  const { data: chatData, loading } = useCustomQuery<GetChat>(GET_CHAT, {
-    variables: { chatId },
-  });
   const [CreateChat] = useCustomMutation(CREATE_CHAT);
+  const { data: chatData } = useCustomQuery<GetChat>(GET_CHAT, {
+    variables: { chatId },
+    onCompleted: (data) => {
+      setChats(data.getChat.chats);
+    },
+  });
   const { data } = useSubscription(SUB_CHAT, {
     variables: {
       chatId,
@@ -71,13 +74,6 @@ const ChatRoom: FC = () => {
   useEffect(() => {
     chatRef.current!.scrollTop = chatRef.current!.scrollHeight;
   }, [chats]);
-
-  useEffect(() => {
-    if (!loading) {
-      const chats = chatData?.getChat.chats as [ChatType];
-      setChats(chats);
-    }
-  }, [loading]);
 
   return (
     <StyledChatRoom>

--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -89,10 +89,6 @@ const GoToDestination: FC = () => {
     },
   });
 
-  const onClickChatRoom = () => {
-    history.push(`/chatroom/${id}`);
-  };
-
   const onCompleteOrderHandler = useCallback(() => {
     closeModal();
     dispatch(resetOrder());
@@ -145,9 +141,6 @@ const GoToDestination: FC = () => {
             {'현재요금: '}
             {numberWithCommas(taxiFee)}
           </span>
-          <Button className="driver-chat-btn" onClick={onClickChatRoom}>
-            손님과의 채팅
-          </Button>
           <Button
             className="driver-arrive-btn"
             type="primary"

--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -141,7 +141,10 @@ const GoToDestination: FC = () => {
         directions={directions}
       >
         <StyledGoToDestinationMenu>
-          <span>현재요금: {numberWithCommas(taxiFee)}</span>
+          <span>
+            {'현재요금: '}
+            {numberWithCommas(taxiFee)}
+          </span>
           <Button className="driver-chat-btn" onClick={onClickChatRoom}>
             손님과의 채팅
           </Button>
@@ -158,10 +161,22 @@ const GoToDestination: FC = () => {
         {orderInfo && (
           <OrderInfo>
             <div className="order-info-title">운행이 완료되었습니다</div>
-            <div>출발지: {orderInfo?.startingPoint.address}</div>
-            <div>목적지: {orderInfo?.destination.address}</div>
-            <div>결제비: {orderInfo?.amount}</div>
-            <div>이동시간: {calcDriveTime(orderInfo?.completedAt, orderInfo?.startedAt)}</div>
+            <div>
+              {'출발지: '}
+              {orderInfo?.startingPoint.address}
+            </div>
+            <div>
+              {'목적지: '}
+              {orderInfo?.destination.address}
+            </div>
+            <div>
+              {'결제비: '}
+              {orderInfo?.amount}
+            </div>
+            <div>
+              {'이동시간: '}
+              {calcDriveTime(orderInfo?.completedAt, orderInfo?.startedAt)}
+            </div>
           </OrderInfo>
         )}
       </Modal>

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -8,9 +8,8 @@ import MapFrame from '@components/MapFrame';
 import { START_DRIVING } from '@queries/order';
 import { UPDATE_DRIVER_LOCATION } from '@queries/user';
 import { UpdateDriverLocation, StartDriving } from '@/types/api';
-import getUserLocation from '@utils/getUserLocation';
 import { useCustomMutation } from '@hooks/useApollo';
-import { InitialState, Location } from '@reducers/.';
+import { InitialState } from '@reducers/.';
 
 const StyledDriverGoToOriginMenu = styled.section`
   height: 100%;

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -55,6 +55,10 @@ const GoToOrigin: FC = () => {
   });
   const history = useHistory();
 
+  const onClickChatRoom = () => {
+    history.push(`/chatroom/${id}`);
+  };
+
   const watchUpdateCurrentLocation = useCallback((location: Position) => {
     setCurrentLocation({
       lat: location.coords.latitude,
@@ -90,6 +94,9 @@ const GoToOrigin: FC = () => {
               <div className="driver-start-order-info">손님이 탑승하시고 나서 눌러주세요.</div>
               <Button onClick={onClickStartDrive} type="primary">
                 운행시작
+              </Button>
+              <Button className="driver-chat-btn" onClick={onClickChatRoom}>
+                손님과의 채팅
               </Button>
             </div>
           </StyledDriverGoToOriginMenu>

--- a/server/src/api/chat/createChat/createChat.graphql
+++ b/server/src/api/chat/createChat/createChat.graphql
@@ -5,5 +5,5 @@ type CreateChatResponse {
 }
 
 type Mutation {
-  createChat(chatId: String!, content: String!, writer: String!, createdAt: String!): CreateChatResponse!
+  createChat(chatId: String!, content: String!): CreateChatResponse! @auth
 }

--- a/server/src/api/chat/createChat/createChat.resolvers.ts
+++ b/server/src/api/chat/createChat/createChat.resolvers.ts
@@ -5,12 +5,11 @@ import { NEW_CHAT } from '@api/chat/subChat/subChat.resolvers';
 
 const resolvers: Resolvers = {
   Mutation: {
-    createChat: async (_, { chatId, content, writer, createdAt }, { pubsub }) => {
+    createChat: async (_, { chatId, content }, { req, pubsub }) => {
       const payload = {
         chatId,
         content,
-        writer,
-        createdAt,
+        writer: req.user?._id as string,
       };
       const { result, chat, error } = await insertChat(payload);
 

--- a/server/src/api/shared/type.graphql
+++ b/server/src/api/shared/type.graphql
@@ -18,7 +18,7 @@ input LocationInfo {
 }
 
 type Chat {
-    createdAt: String!
-    writer: String!
-    content: String!
+  createdAt: String
+  writer: String!
+  content: String!
 }

--- a/server/src/services/chat/createChat.ts
+++ b/server/src/services/chat/createChat.ts
@@ -5,14 +5,13 @@ interface Props {
   chatId: string;
   content: string;
   writer: string;
-  createdAt: string;
 }
 
-const insertChat = async ({ writer, createdAt, chatId, content }: Props) => {
+const insertChat = async ({ writer, chatId, content }: Props) => {
   try {
     const { ok: isUpdated } = await OrderModel.updateOne(
       { _id: chatId },
-      { $push: { chat: { writer, content, createdAt } } },
+      { $push: { chat: { writer, content } } },
     );
 
     if (!isUpdated) {
@@ -21,7 +20,6 @@ const insertChat = async ({ writer, createdAt, chatId, content }: Props) => {
 
     const newChat = {
       writer,
-      createdAt,
       content,
     };
 


### PR DESCRIPTION
### 작업 사항
- [x] server, client 뮤테이션 변경
- [x] ChatRoom, ChatLog 컴포넌트 리팩토링
- [x] 드라이버 화면에서 채팅방 입장 버튼을 GoToDestination -> GoToOrigin 컴포넌트로 변경
- [x] 채팅방 나간 상태에서 채팅이 추가됐을 때 정상적으로 업데이트 되지 않던 문제 해결


### 요약
- client에서 content, chatId만 보내고 server에서 writer, createdAt을 추가로 넣어줘서 채팅을 생성할 수 있도록 변경했습니다.
- 지금 ChatRoom에서 map을 돌 때 유니크한 키 값을 줘야하는데, 유니크한 속성이 없어서 어떻게 해야할 지 모르겠습니다. 인덱스로 해결하려했는데 인덱스로 주니 린트가 에러를 띄워서,, 좋은 방법 있으면 추천해주세요!
- subscriptionToMore를 사용하면 캐시를 업데이트 시킬 수 있는데, 드라이버와 사용자 각각 다른 client를 가지고 있기 때문에 채팅방에 나간 상태에서 채팅이 추가되면 업데이트가 정상적으로 되지 않아 useSubscription 사용해서 리팩토링 진행했습니다.


### 첨부
![image](https://user-images.githubusercontent.com/52775389/101276219-8818c180-37ee-11eb-8dfb-566713799892.png)

### 이슈
#166 #173 #180 