### PR TITLE
[CY] 유저(일반 사용자 및 드라이버) 로그아웃 API 구현

### DIFF
--- a/server/src/api/user/logout/logout.graphql
+++ b/server/src/api/user/logout/logout.graphql
@@ -1,0 +1,8 @@
+type LogoutResponse {
+  result: String!
+  error: String
+}
+
+type Mutation {
+  logout: LogoutResponse! @auth
+}

--- a/server/src/api/user/logout/logout.resolvers.ts
+++ b/server/src/api/user/logout/logout.resolvers.ts
@@ -1,0 +1,22 @@
+import { Resolvers } from '@type/api';
+
+import deleteRefreshToken from '@services/user/deleteRefreshToken';
+
+const JWT_HEADER = process.env.JWT_HEADER as string;
+
+const resolvers: Resolvers = {
+  Mutation: {
+    logout: async (_, __, { req, res }) => {
+      const { result, error } = await deleteRefreshToken(req.user?._id || '');
+
+      if (result === 'fail' || error) {
+        return { result, error };
+      }
+
+      res.clearCookie(JWT_HEADER);
+      return { result };
+    },
+  },
+};
+
+export default resolvers;

--- a/server/src/services/user/deleteRefreshToken.ts
+++ b/server/src/services/user/deleteRefreshToken.ts
@@ -1,0 +1,12 @@
+import User from '@models/user';
+
+const deleteRefreshToken = async (userId: string) => {
+  try {
+    await User.findByIdAndUpdate(userId, { refreshToken: null });
+    return { result: 'success' };
+  } catch (err) {
+    return { result: 'fail', error: err.message };
+  }
+};
+
+export default deleteRefreshToken;


### PR DESCRIPTION
### 작업 사항
- [x] refreshToken 초기화 서비스 로직 구현
- [x] 유저 로그아웃 API 구현


### 요약
유저(일반 사용자 및 드라이버) 로그아웃 API 구현


### 첨부
![image](https://user-images.githubusercontent.com/49899406/101275930-feb4bf80-37ec-11eb-8f19-de0b14a46391.png)


### 이슈
#178 