### PR TITLE
[hj] 사용자 오더 기록 조회 cypress 테스트

### DIFF
--- a/client/cypress/integration/OrderHistory.spec.ts
+++ b/client/cypress/integration/OrderHistory.spec.ts
@@ -1,0 +1,31 @@
+describe('OrderHistory 컴포넌트 테스트', () => {
+  before(() => {
+    cy.setCookie(Cypress.env('TOKEN_NAME'), Cypress.env('USER_TOKEN'));
+    cy.visit('/user');
+  });
+
+  it('일반 사용자가 헤더 메뉴를 클릭하면 좌측에서 우측으로 사이드바 메뉴가 화면에 나타난다.', () => {
+    cy.get("[data-testID='header-menu-toggle']").click();
+    cy.get("[data-testID='header-menu']").should('exist');
+  });
+
+  it('일반 사용자가 사이드바메뉴에서 이용기록 조회를 클릭하면 오더조회 페이지로 이동한다.', () => {
+    cy.get("[data-testID='history-button']").click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/orderHistory`);
+    cy.clearCookie(Cypress.env('TOKEN_NAME'));
+  });
+
+  it('드라이버가 헤더 메뉴를 클릭하면 좌측에서 우측으로 사이드바 메뉴가 화면에 나타난다.', () => {
+    cy.setCookie(Cypress.env('TOKEN_NAME'), Cypress.env('DRIVER_TOKEN'));
+    cy.visit('/driver');
+    cy.get("[data-testID='header-menu-toggle']").click();
+    cy.get("[data-testID='header-menu']").should('exist');
+  });
+
+  it('드라이버가 사이드바메뉴에서 이용기록 조회를 클릭하면 오더조회 페이지로 이동한다.', () => {
+    cy.get("[data-testID='history-button']").click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/orderHistory`);
+  });
+});
+
+export default {};

--- a/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
+++ b/client/src/components/HeaderWithMenu/HeaderWithMenu.tsx
@@ -77,13 +77,13 @@ const HeaderWithMenu: FC<Props> = ({ className = 'white-header' }) => {
 
   return (
     <StyledHeaderWithMenu className={className} isMenuOpen={menu}>
-      <button type="button" onClick={toggleMenu}>
+      <button type="button" data-testID="header-menu-toggle" onClick={toggleMenu}>
         <MenuSVG />
       </button>
-      <menu>
+      <menu data-testID="header-menu">
         <ul>
           <li>
-            <button type="button" onClick={onClickCompletedOrders}>
+            <button type="button" data-testID="history-button" onClick={onClickCompletedOrders}>
               이용 기록
             </button>
           </li>


### PR DESCRIPTION
### 작업 사항
- [x]  헤더 메뉴 클릭시 사이드 메뉴 나타나는것 확인
- [x] 이용기록조회시, 이용기록조회 페이지로 이동

### 첨부
![image](https://user-images.githubusercontent.com/49400477/101560979-cb9a4800-3a07-11eb-8e4c-b03117bb6112.png)


### 이슈
#192 