### PR TITLE
[JE] 채팅 메시지 생성, 오더 취소, 드라이버 운행 시작 API 테스트 코드 작성

### DIFF
--- a/server/__test__/chat.spec.ts
+++ b/server/__test__/chat.spec.ts
@@ -2,9 +2,18 @@ import { gql } from 'apollo-server-express';
 import { connect, disconnect } from './testMongoose';
 import client, { UserType } from './testApollo';
 
-import { activeOrderId } from './mock.json';
+import { activeOrderId, createChatId } from './mock.json';
 
 const { TEST_USER } = process.env;
+
+const CREATE_CHAT = gql`
+  mutation CreateChat($content: String!, $chatId: String!) {
+    createChat(content: $content, chatId: $chatId) {
+      result
+      error
+    }
+  }
+`;
 
 const GET_CHATS = gql`
   query GetChat($chatId: String!) {
@@ -19,10 +28,25 @@ const GET_CHATS = gql`
   }
 `;
 
-const { query } = client(UserType.user);
+const { query, mutate } = client(UserType.user);
 describe('채팅 API 테스트', () => {
   beforeAll(() => {
     connect();
+  });
+
+  test('채팅 메시지 생성', async () => {
+    const {
+      data: {
+        createChat: { result, error },
+      },
+    } = await mutate({
+      mutation: CREATE_CHAT,
+      variables: { chatId: createChatId, content: 'some content' },
+    });
+
+    expect(result).toBe('success');
+
+    expect(error).toEqual(null);
   });
 
   test('채팅 목록 조회', async () => {

--- a/server/__test__/chat.spec.ts
+++ b/server/__test__/chat.spec.ts
@@ -39,10 +39,10 @@ describe('채팅 API 테스트', () => {
       data: {
         createChat: { result, error },
       },
-    } = await mutate({
+    } = (await mutate({
       mutation: CREATE_CHAT,
       variables: { chatId: createChatId, content: 'some content' },
-    });
+    })) as any;
 
     expect(result).toBe('success');
 

--- a/server/__test__/mock.json
+++ b/server/__test__/mock.json
@@ -14,5 +14,7 @@
     "startedAt": "1607346408235",
     "amount": 3000,
     "completedAt": "1607346408961"
-  }
+  },
+  "createChatId": "5fce27f7d573726ab8a94bfd",
+  "cancelOrderId": "5fce28b0d573726ab8a94c04"
 }

--- a/server/__test__/mock.json
+++ b/server/__test__/mock.json
@@ -16,5 +16,6 @@
     "completedAt": "1607346408961"
   },
   "createChatId": "5fce27f7d573726ab8a94bfd",
-  "cancelOrderId": "5fce28b0d573726ab8a94c04"
+  "cancelOrderId": "5fce28b0d573726ab8a94c04",
+  "startDrivingOrderId": "5fce289fd573726ab8a94c02"
 }

--- a/server/__test__/order.spec.ts
+++ b/server/__test__/order.spec.ts
@@ -2,11 +2,20 @@ import { gql } from 'apollo-server-express';
 import { connect, disconnect } from './testMongoose';
 import client, { UserType } from './testApollo';
 
-import { completedOrder } from './mock.json';
+import { completedOrder, cancelOrderId, startDrivingOrderId } from './mock.json';
 
 const CANCEL_ORDER = gql`
   mutation CancelOrder($orderId: String!) {
     cancelOrder(orderId: $orderId) {
+      result
+      error
+    }
+  }
+`;
+
+const START_DRIVING = gql`
+  mutation StartDriving($orderId: String!) {
+    startDriving(orderId: $orderId) {
       result
       error
     }
@@ -50,7 +59,22 @@ describe('사용자의 완료된 오더 조회', () => {
       },
     } = (await mutate({
       mutation: CANCEL_ORDER,
-      variables: { orderId: '5fce28b0d573726ab8a94c04' },
+      variables: { orderId: cancelOrderId },
+    })) as any;
+
+    expect(result).toBe('success');
+
+    expect(error).toBe(null);
+  });
+
+  test('드라이버 운행 시작', async () => {
+    const {
+      data: {
+        startDriving: { result, error },
+      },
+    } = (await mutate({
+      mutation: START_DRIVING,
+      variables: { orderId: startDrivingOrderId },
     })) as any;
 
     expect(result).toBe('success');

--- a/server/__test__/order.spec.ts
+++ b/server/__test__/order.spec.ts
@@ -47,6 +47,8 @@ const GET_COMPLETED_ORDERS = gql`
 `;
 
 const { query, mutate } = client(UserType.user);
+const driverClient = client(UserType.driver);
+
 describe('사용자의 완료된 오더 조회', () => {
   beforeAll(() => {
     connect();
@@ -72,7 +74,7 @@ describe('사용자의 완료된 오더 조회', () => {
       data: {
         startDriving: { result, error },
       },
-    } = (await mutate({
+    } = (await driverClient.mutate({
       mutation: START_DRIVING,
       variables: { orderId: startDrivingOrderId },
     })) as any;

--- a/server/__test__/order.spec.ts
+++ b/server/__test__/order.spec.ts
@@ -4,6 +4,15 @@ import client, { UserType } from './testApollo';
 
 import { completedOrder } from './mock.json';
 
+const CANCEL_ORDER = gql`
+  mutation CancelOrder($orderId: String!) {
+    cancelOrder(orderId: $orderId) {
+      result
+      error
+    }
+  }
+`;
+
 const GET_COMPLETED_ORDERS = gql`
   query GetCompletedOrders {
     getCompletedOrders {
@@ -28,10 +37,25 @@ const GET_COMPLETED_ORDERS = gql`
   }
 `;
 
-const { query } = client(UserType.user);
+const { query, mutate } = client(UserType.user);
 describe('사용자의 완료된 오더 조회', () => {
   beforeAll(() => {
     connect();
+  });
+
+  test('오더 취소', async () => {
+    const {
+      data: {
+        cancelOrder: { result, error },
+      },
+    } = await mutate({
+      mutation: CANCEL_ORDER,
+      variables: { orderId: '5fce28b0d573726ab8a94c04' },
+    });
+
+    expect(result).toBe('success');
+
+    expect(error).toBe(null);
   });
 
   test('완료된 오더 조회', async () => {

--- a/server/__test__/order.spec.ts
+++ b/server/__test__/order.spec.ts
@@ -66,7 +66,7 @@ describe('사용자의 완료된 오더 조회', () => {
 
     expect(result).toBe('success');
 
-    expect(error).toBe(null);
+    expect(error).toEqual(null);
   });
 
   test('드라이버 운행 시작', async () => {
@@ -81,7 +81,7 @@ describe('사용자의 완료된 오더 조회', () => {
 
     expect(result).toBe('success');
 
-    expect(error).toBe(null);
+    expect(error).toEqual(null);
   });
 
   test('완료된 오더 조회', async () => {

--- a/server/__test__/order.spec.ts
+++ b/server/__test__/order.spec.ts
@@ -48,10 +48,10 @@ describe('사용자의 완료된 오더 조회', () => {
       data: {
         cancelOrder: { result, error },
       },
-    } = await mutate({
+    } = (await mutate({
       mutation: CANCEL_ORDER,
       variables: { orderId: '5fce28b0d573726ab8a94c04' },
-    });
+    })) as any;
 
     expect(result).toBe('success');
 

--- a/server/__test__/testApollo.ts
+++ b/server/__test__/testApollo.ts
@@ -45,7 +45,7 @@ const client = (type: UserType): ApolloServerTestClient => {
     context: (ctx) => ({
       ...ctx,
       req: RequestUser[type],
-      pubsub: jest.fn(),
+      pubsub: { publish: jest.fn() },
     }),
   });
 

--- a/server/seeders/orders.seeder.json
+++ b/server/seeders/orders.seeder.json
@@ -110,6 +110,31 @@
       "startedAt": "2020-12-07T13:06:48.235Z",
       "amount": 3000,
       "completedAt": "2020-12-07T13:06:48.961Z"
+    },
+    {
+      "_id": "5fce27f7d573726ab8a94bfe",
+      "user": "5fbc9eacadc14b373c78f376",
+      "startingPoint": {
+        "coordinates": [51.5091391, -0.1238953],
+        "address": "Superdrug, 스트랜드 런던 영국"
+      },
+      "destination": {
+        "coordinates": [51.5073509, -0.1277583],
+        "address": "London, 영국"
+      },
+      "payment": {
+        "bank": "국민은행",
+        "creditNumber": "1233-2213-2132-1321",
+        "expiryDate": "12/19",
+        "cvc": 123
+      },
+      "status": "approval",
+      "chat": [],
+      "createdAt": "2020-12-07T13:02:47.063Z",
+      "__v": 0,
+      "driver": "5fcf36023305a041dc2dd7fc",
+      "startedAt": "2020-12-07T13:04:39.095Z",
+      "completedAt": "2020-12-07T13:04:39.843Z"
     }
   ]
 }

--- a/server/seeders/orders.seeder.json
+++ b/server/seeders/orders.seeder.json
@@ -112,7 +112,33 @@
       "completedAt": "2020-12-07T13:06:48.961Z"
     },
     {
-      "_id": "5fce27f7d573726ab8a94bfe",
+      "_id": "5fce289fd573726ab8a94c02",
+      "user": "5fbc9eacadc14b373c78f376",
+      "startingPoint": {
+        "coordinates": [51.5091391, -0.1238953],
+        "address": "Superdrug, 스트랜드 런던 영국"
+      },
+      "destination": {
+        "coordinates": [51.5073509, -0.1277583],
+        "address": "London, 영국"
+      },
+      "payment": {
+        "bank": "국민은행",
+        "creditNumber": "1233-2213-2132-1321",
+        "expiryDate": "12/19",
+        "cvc": 123
+      },
+      "status": "waiting",
+      "chat": [],
+      "createdAt": "2020-12-07T13:06:44.038Z",
+      "__v": 0,
+      "driver": "5fcf36023305a041dc2dd7fc",
+      "startedAt": "2020-12-07T13:06:48.235Z",
+      "amount": 3000,
+      "completedAt": "2020-12-07T13:06:48.961Z"
+    },
+    {
+      "_id": "5fce28b0d573726ab8a94c04",
       "user": "5fbc9eacadc14b373c78f376",
       "startingPoint": {
         "coordinates": [51.5091391, -0.1238953],
@@ -130,11 +156,37 @@
       },
       "status": "approval",
       "chat": [],
-      "createdAt": "2020-12-07T13:02:47.063Z",
+      "createdAt": "2020-12-07T13:06:44.038Z",
       "__v": 0,
       "driver": "5fcf36023305a041dc2dd7fc",
-      "startedAt": "2020-12-07T13:04:39.095Z",
-      "completedAt": "2020-12-07T13:04:39.843Z"
+      "startedAt": "2020-12-07T13:06:48.235Z",
+      "amount": 3000,
+      "completedAt": "2020-12-07T13:06:48.961Z"
+    },
+    {
+      "_id": "5fce28bed573726ab8a94c05",
+      "user": "5fbc9eacadc14b373c78f376",
+      "startingPoint": {
+        "coordinates": [51.5091391, -0.1238953],
+        "address": "Superdrug, 스트랜드 런던 영국"
+      },
+      "destination": {
+        "coordinates": [51.5073509, -0.1277583],
+        "address": "London, 영국"
+      },
+      "payment": {
+        "bank": "국민은행",
+        "creditNumber": "1233-2213-2132-1321",
+        "expiryDate": "12/19",
+        "cvc": 123
+      },
+      "status": "startedDrive",
+      "chat": [],
+      "createdAt": "2020-12-07T13:06:44.038Z",
+      "__v": 0,
+      "driver": "5fcf36023305a041dc2dd7fc",
+      "startedAt": "2020-12-07T13:06:48.235Z",
+      "amount": 3000
     }
   ]
 }


### PR DESCRIPTION
### 작업 사항
- [x] 채팅 메시지 생성 API 테스트 코드 작성
- [x]  오더 취소 API 테스트 코드 작성
- [x] 드라이버 운행 시작 API 테스트 코드 작성

### 요약
서버쪽 API에 대한 테스트 코드를 작성했습니다.

### 첨부
![image](https://user-images.githubusercontent.com/43084680/101607300-cbba3800-3a47-11eb-8f73-3c57225c7e29.png)


### 이슈
#199 