### PR TITLE
[JH] SearchDriver 페이지 antd 마이그레이션 작업

### DIFF
--- a/client/src/routes/User/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/User/SearchDriver/SearchDriver.tsx
@@ -4,9 +4,8 @@ import { useSubscription } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
 
 import styled from '@theme/styled';
-import Header from '@components/HeaderWithMenu';
 import Modal from '@components/Modal';
-import { Spin, Space, Button, message } from 'antd';
+import { Spin, Button, message, Layout, Row, Col } from 'antd';
 import CarInfo from '@components/CarInfo';
 import { InitialState } from '@reducers/.';
 import { SUB_ORDER_CALL_STATUS, GET_ORDER_CAR_INFO, CANCEL_ORDER } from '@/queries/order';
@@ -17,34 +16,31 @@ import useModal from '@hooks/useModal';
 import { addCarInfo } from '@reducers/order';
 import { Message } from '@utils/client-message';
 
+const { Header, Content } = Layout;
+
 const StyledSearchDriver = styled.div`
-  margin-bottom: 0.8rem;
   height: 100%;
 
-  & > section {
+  & .ant-layout-content {
     position: relative;
-    height: calc(100% - 50px);
-    position: relative;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
+    height: calc(100% - 64px);
+  }
 
-    & > .loading-center {
-      position: absolute;
-      left: 50%;
-      top: 40%;
-      transform: translateX(-50%);
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      font-weight: 700;
+  .ant-btn {
+    width: 100%;
+  }
 
-      & > div {
-        margin-top: 1rem;
-      }
-    }
+  & .search-spinner {
+    position: absolute;
+    width: 100%;
+    left: 50%;
+    top: 40%;
+    transform: translateX(-50%);
+  }
+
+  & .cancel-button {
+    height: 100%;
+    padding-bottom: 1.5rem;
   }
 `;
 
@@ -97,20 +93,23 @@ const SearchDriver: FC = () => {
   return (
     <>
       <StyledSearchDriver>
-        <Header className="green-header" />
-        <section>
-          <div className="loading-center">
-            주변에 운행이 가능한 드라이버를 탐색중입니다
-            {!isModal && (
-              <Space>
-                <Spin size="large" />
-              </Space>
-            )}
-          </div>
-          <Button danger onClick={onClickCancelOrderHandler}>
-            탐색 취소
-          </Button>
-        </section>
+        <Header />
+        <Content>
+          {!isModal && (
+            <>
+              <Row className="search-spinner" align="middle" justify="center">
+                <Spin size="large" tip="주변에 운행이 가능한 드라이버를 탐색중입니다." />
+              </Row>
+              <Row className="cancel-button" justify="center" align="bottom">
+                <Col span={22}>
+                  <Button danger onClick={onClickCancelOrderHandler}>
+                    탐색 취소
+                  </Button>
+                </Col>
+              </Row>
+            </>
+          )}
+        </Content>
       </StyledSearchDriver>
       <Modal visible={isModal} onClose={onClickModalCloseHandler}>
         {carInfo && <CarInfo carInfo={carInfo} title={Message.DriverMatchingCompolete} />}

--- a/client/src/routes/User/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/User/SearchDriver/SearchDriver.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useSubscription } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
@@ -45,6 +45,7 @@ const { Header, Content } = Layout;
 const SearchDriver: FC = () => {
   const history = useHistory();
   const dispatch = useDispatch();
+  const [isDisabled, SetIsDisabled] = useState(false);
   const { callQuery } = useCustomQuery<GetOrderCarInfo>(GET_ORDER_CAR_INFO, {
     skip: true,
   });
@@ -68,6 +69,7 @@ const SearchDriver: FC = () => {
   });
 
   const openNotificationWithIcon = (options: ArgsProps) => {
+    SetIsDisabled(true);
     notification.success({
       ...options,
       key: 'updatable',
@@ -113,7 +115,7 @@ const SearchDriver: FC = () => {
           </Row>
           <Row className="cancel-button" justify="center" align="bottom">
             <Col span={22}>
-              <Button danger onClick={onClickCancelOrderHandler}>
+              <Button danger disabled={isDisabled} onClick={onClickCancelOrderHandler}>
                 탐색 취소
               </Button>
             </Col>

--- a/client/src/routes/User/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/User/SearchDriver/SearchDriver.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback } from 'react';
-import { Button, ActivityIndicator, Toast } from 'antd-mobile';
 import { useSelector, useDispatch } from 'react-redux';
 import { useSubscription } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
@@ -7,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 import styled from '@theme/styled';
 import Header from '@components/HeaderWithMenu';
 import Modal from '@components/Modal';
+import { Spin, Space, Button, message } from 'antd';
 import CarInfo from '@components/CarInfo';
 import { InitialState } from '@reducers/.';
 import { SUB_ORDER_CALL_STATUS, GET_ORDER_CAR_INFO, CANCEL_ORDER } from '@/queries/order';
@@ -45,18 +45,6 @@ const StyledSearchDriver = styled.div`
         margin-top: 1rem;
       }
     }
-
-    & > .am-button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      height: 2rem;
-      margin-bottom: 0.8rem;
-      margin-top: 2rem;
-      font-weight: 700;
-      font-size: 0.9rem;
-    }
   }
 `;
 
@@ -80,7 +68,7 @@ const SearchDriver: FC = () => {
   const [cancelOrderMutation] = useCustomMutation<CancelOrder>(CANCEL_ORDER, {
     onCompleted: ({ cancelOrder }) => {
       if (cancelOrder.result === 'fail') {
-        Toast.fail(Message.FailureCancelOrder);
+        message.error(Message.FailureCancelOrder);
         return;
       }
       history.push('/user');
@@ -113,9 +101,13 @@ const SearchDriver: FC = () => {
         <section>
           <div className="loading-center">
             주변에 운행이 가능한 드라이버를 탐색중입니다
-            {!isModal && <ActivityIndicator size="large" />}
+            {!isModal && (
+              <Space>
+                <Spin size="large" />
+              </Space>
+            )}
           </div>
-          <Button type="warning" onClick={onClickCancelOrderHandler}>
+          <Button danger onClick={onClickCancelOrderHandler}>
             탐색 취소
           </Button>
         </section>


### PR DESCRIPTION
### 작업 사항
- [x] 전체적인 스타일 antd로 변경
- [x] Modal 컴포넌트 CarInfo 컴포넌트 사용 X
- [x] Notification 컴포넌트 사용하여 배차완료 알림 및 배차 정보 표시


### 요약
- SearchDriver 페이지 antd 마이그레이션 작업 완료했습니다.
- 기존에 커스텀모달 사용하면 부분을 제거하고 Notification 컴포넌트 활용하여 구현했습니다.
- 배차 완료 알람을 받았을 때 탐색취소 버튼이 비활성화 되도록 구현했습니다.


### 첨부
![Dec-10-2020 17-28-48](https://user-images.githubusercontent.com/52775389/101741266-371a0d80-3b0d-11eb-91ef-94590028917c.gif)


### 이슈
#215 