### PR TITLE
[CY] 채팅 알림 기능 구현

### DIFF
--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -21,6 +21,11 @@ const StyledChatLogWrapper = styled.div<Type>`
   display: flex;
   flex-direction: ${({ type, writer }) => type === writer && 'row-reverse'};
   padding: 0.3rem 0.5rem;
+
+  & .ant-tag {
+    margin-left: ${({ writer, preWriter }) => writer === preWriter && '2.5rem'};
+    border: none;
+  }
 `;
 
 const avartarMapper = (avartar: string): string => {

--- a/client/src/hooks/useChatNotifycation.ts
+++ b/client/src/hooks/useChatNotifycation.ts
@@ -5,12 +5,17 @@ import { SUB_CHAT } from '@queries/chat';
 import { SubChat } from '@/types/api';
 
 const CHAT_DURATION = 1;
+const CHAT_MAX_COUNT = 5;
 
 const useChatNotifycation = (id: string) => {
   const subscriptionResult = useSubscription<SubChat>(SUB_CHAT, {
     variables: { chatId: id },
     onSubscriptionData: ({ subscriptionData }) => {
       if (subscriptionData.data?.subChat.chat) {
+        message.config({
+          duration: CHAT_DURATION,
+          maxCount: CHAT_MAX_COUNT,
+        });
         message.info(subscriptionData.data.subChat.chat.content, CHAT_DURATION);
       }
     },

--- a/client/src/hooks/useChatNotifycation.ts
+++ b/client/src/hooks/useChatNotifycation.ts
@@ -1,0 +1,20 @@
+import { useSubscription } from '@apollo/react-hooks';
+import { message } from 'antd';
+
+import { SUB_CHAT } from '@queries/chat';
+import { SubChat } from '@/types/api';
+
+const useChatNotifycation = (id: string) => {
+  const subscriptionResult = useSubscription<SubChat>(SUB_CHAT, {
+    variables: { chatId: id },
+    onSubscriptionData: ({ subscriptionData }) => {
+      if (subscriptionData.data?.subChat.chat) {
+        message.info(subscriptionData.data.subChat.chat.content, 1);
+      }
+    },
+  });
+
+  return subscriptionResult;
+};
+
+export default useChatNotifycation;

--- a/client/src/hooks/useChatNotifycation.ts
+++ b/client/src/hooks/useChatNotifycation.ts
@@ -4,12 +4,14 @@ import { message } from 'antd';
 import { SUB_CHAT } from '@queries/chat';
 import { SubChat } from '@/types/api';
 
+const CHAT_DURATION = 1;
+
 const useChatNotifycation = (id: string) => {
   const subscriptionResult = useSubscription<SubChat>(SUB_CHAT, {
     variables: { chatId: id },
     onSubscriptionData: ({ subscriptionData }) => {
       if (subscriptionData.data?.subChat.chat) {
-        message.info(subscriptionData.data.subChat.chat.content, 1);
+        message.info(subscriptionData.data.subChat.chat.content, CHAT_DURATION);
       }
     },
   });

--- a/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/Driver/GoToDestination/GoToDestination.tsx
@@ -12,6 +12,7 @@ import {
   getOrderById_getOrderById_order as OrderType,
 } from '@/types/api';
 import { useCustomMutation, useCustomQuery } from '@hooks/useApollo';
+import useChatNotifycation from '@hooks/useChatNotifycation';
 import styled from '@/theme/styled';
 import getUserLocation from '@utils/getUserLocation';
 import { DRIVER } from '@utils/enums';
@@ -48,6 +49,8 @@ const GoToDestination: FC = () => {
   const [updateDriverLocationMutation] = useCustomMutation<UpdateDriverLocation>(
     UPDATE_DRIVER_LOCATION,
   );
+
+  useChatNotifycation(id || '');
 
   useEffect(() => {
     if (orderInfo) {

--- a/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
+++ b/client/src/routes/Driver/GoToOrigin/GoToOrigin.tsx
@@ -8,6 +8,7 @@ import { START_DRIVING } from '@queries/order';
 import { UPDATE_DRIVER_LOCATION } from '@queries/user';
 import { UpdateDriverLocation, StartDriving } from '@/types/api';
 import { useCustomMutation } from '@hooks/useApollo';
+import useChatNotifycation from '@hooks/useChatNotifycation';
 import { InitialState } from '@reducers/.';
 import { Button, Row, Col } from 'antd';
 
@@ -39,6 +40,9 @@ const GoToOrigin: FC = () => {
       }
     },
   });
+
+  useChatNotifycation(id || '');
+
   const history = useHistory();
 
   const onClickChatRoom = () => {

--- a/client/src/routes/User/GoToDestination/GoToDestination.tsx
+++ b/client/src/routes/User/GoToDestination/GoToDestination.tsx
@@ -16,6 +16,7 @@ import {
   getOrderById_getOrderById_order as OrderType,
 } from '@/types/api';
 import { useCustomQuery } from '@hooks/useApollo';
+import useChatNotifycation from '@hooks/useChatNotifycation';
 import { OrderCallStatus } from '@/types/orderCallStatus';
 import { InitialState, Location } from '@reducers/.';
 import { resetOrder } from '@reducers/order';
@@ -41,6 +42,8 @@ const GoToDestination: FC = () => {
   const [driverLocation, setDriverLocation] = useState<Location>();
   const [orderInfo, setorderInfo] = useState<OrderType | null>();
   const { callQuery } = useCustomQuery<getOrderById>(GET_ORDER_BY_ID, { skip: true });
+
+  useChatNotifycation(orderId || '');
 
   useEffect(() => {
     if (orderInfo) {

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -19,6 +19,7 @@ import {
 
 import { OrderCallStatus } from '@/types/orderCallStatus';
 import { useCustomQuery } from '@hooks/useApollo';
+import useChatNotifycation from '@hooks/useChatNotifycation';
 import { calcLocationDistance } from '@utils/calcLocationDistance';
 import { InitialState } from '@reducers/.';
 import { ModalFuncProps } from 'antd/lib/modal/Modal';
@@ -41,6 +42,8 @@ const WaitingDriver = () => {
   const [carInfo, setCarInfo] = useState({ carNumber: '', carType: 'small' } as CarInfoType);
   const { id } = useSelector(({ order }: InitialState) => order || {});
   const { origin: userOrigin } = useSelector(({ order }: InitialState) => order.location);
+
+  useChatNotifycation(id || '');
 
   useEffect(() => {
     setModalItem({


### PR DESCRIPTION
### 작업 사항
- [x] 채팅 알림 커스텀 훅 구현
- [x] 드라이버의 GoToOrigin, GoToDestination 페이지에 채팅 알림 기능 적용
- [x] 일반 사용자의 waitingDriver, GoToDestination 페이지에 채팅 알림 기능 적용


### 요약
채팅 알림 기능 구현 및 레이아웃 재정리


### 첨부
![chat](https://user-images.githubusercontent.com/49899406/102001721-91e37d00-3d38-11eb-9652-ac8837705f56.gif)


### 이슈
#202 