### PR TITLE
[JE] 운행 시간 계산 함수 수정

### DIFF
--- a/client/src/utils/calcDriveTime.ts
+++ b/client/src/utils/calcDriveTime.ts
@@ -2,16 +2,18 @@ const calcDriveTime = (start: string | null, end: string | null) => {
   if (start && end) {
     const startTime = new Date(Number(start)).getTime();
     const endTime = new Date(Number(end)).getTime();
-    let diffInMilliSeconds = Math.abs(startTime - endTime);
+    let diffInMilliSeconds = Math.abs(startTime - endTime) / 1000;
 
     const hours = Math.floor(diffInMilliSeconds / 3600) % 24;
     diffInMilliSeconds -= hours * 3600;
     const minutes = Math.floor(diffInMilliSeconds / 60) % 60;
     diffInMilliSeconds -= minutes * 60;
+    const seconds = Math.floor(diffInMilliSeconds);
 
     let totalTimeInString = '';
     if (hours > 0) totalTimeInString += `${hours}시간 `;
     if (minutes > 0) totalTimeInString += `${minutes}분`;
+    if (seconds > 0) totalTimeInString += `${seconds}초`;
 
     return totalTimeInString;
   }


### PR DESCRIPTION

### 작업 사항
- [x] 시간 계산 함수 수정
- [x] 운행 시간에 초단위도 반환하도록 수정

### 요약
테스트로 오더를 수락하고 닫을 경우 빠르게 진행되다 보니 대부분이 0분으로 나와서 초 단위의 차이도 반환하도록 수정했습니다.


### 첨부
![image](https://user-images.githubusercontent.com/43084680/102005327-61610a80-3d5b-11eb-8747-f14707ccd96f.png)


