### PR TITLE
[JH] 채팅방 채팅 로그 변경, 빈 문자열 전송 못하도록 변경

### DIFF
--- a/client/src/components/ChatLog/ChatLog.tsx
+++ b/client/src/components/ChatLog/ChatLog.tsx
@@ -24,6 +24,9 @@ const StyledChatLogWrapper = styled.div<Type>`
 
   & .ant-tag {
     margin-left: ${({ writer, preWriter }) => writer === preWriter && '2.5rem'};
+    background-color: ${({ theme, type, writer }) =>
+      type === writer ? theme.PRIMARY : theme.BORDER};
+    color: ${({ theme }) => theme.LIGHT};
     border: none;
   }
 `;

--- a/client/src/components/GoogleMap/Directions.tsx
+++ b/client/src/components/GoogleMap/Directions.tsx
@@ -39,7 +39,7 @@ const Directions: FC<Props> = ({ origin, destination, setDirections, directions 
   return (
     <>
       <DirectionsService
-        options={{ origin, destination, travelMode: 'BICYCLING' as google.maps.TravelMode }}
+        options={{ origin, destination, travelMode: 'DRIVING' as google.maps.TravelMode }}
         callback={directionsCallback}
       />
       <DirectionsRenderer directions={directions} options={options} />

--- a/client/src/routes/ChatRoom/ChatRoom.tsx
+++ b/client/src/routes/ChatRoom/ChatRoom.tsx
@@ -70,10 +70,13 @@ const ChatRoom: FC = () => {
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    CreateChat({
-      variables: { chatId, content: chatContent },
-    });
-    setChatContent('');
+
+    if (chatContent.length > 0) {
+      CreateChat({
+        variables: { chatId, content: chatContent },
+      });
+      setChatContent('');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION

### 작업 사항
- [x] 채팅방 페이지 이슈 해결
- [x] Direction API travelMode 변경


### 요약
- 상대방 채팅 회색, 본인 채팅 초록색으로 수정했습니다.
- 빈 문자열을 전송할 수 있는 문제 해결했습니다.
- direction API travelMode를 DRIVING으로 변경했습니다.


### 첨부
![image](https://user-images.githubusercontent.com/52775389/102031794-63c67180-3dfa-11eb-9bd1-41c3fa6d514b.png)


### 이슈
해당 작업 관련 이슈를 태그해주세요.