### PR TITLE
[JH, CY] 사용자, 드라이버 위치 동기화 즉각 안되는 문제 해결

### DIFF
--- a/client/src/components/GoogleMap/Directions.tsx
+++ b/client/src/components/GoogleMap/Directions.tsx
@@ -23,7 +23,7 @@ const Directions: FC<Props> = ({ origin, destination, setDirections, directions 
   };
 
   useEffect(() => {
-    if (count.current === 2) count.current = 0;
+    if (count.current >= 2) count.current = 0;
   }, [origin.lat, origin.lng, destination.lat, destination.lng]);
 
   const directionsCallback = (

--- a/client/src/components/GoogleMap/Directions.tsx
+++ b/client/src/components/GoogleMap/Directions.tsx
@@ -23,14 +23,14 @@ const Directions: FC<Props> = ({ origin, destination, setDirections, directions 
   };
 
   useEffect(() => {
-    count.current = 0;
+    if (count.current === 2) count.current = 0;
   }, [origin.lat, origin.lng, destination.lat, destination.lng]);
 
   const directionsCallback = (
     result: google.maps.DirectionsResult,
     status: google.maps.DirectionsStatus,
   ): void => {
-    if (status === 'OK' && count.current === 0) {
+    if (status === 'OK' && count.current < 2) {
       count.current += 1;
       setDirections!(result);
     }

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -86,7 +86,8 @@ const WaitingDriver = () => {
         lng: subscriptionData.data?.subDriverLocation.coordinates[1] as number,
       };
       setDriverLocation(driverNewLocation);
-      if (!didCloseModal && userOrigin && calcLocationDistance(driverLocation, userOrigin) < 100) {
+      const diffDistance = directions?.routes[0].legs[0].distance.value;
+      if (!didCloseModal && userOrigin && diffDistance !== undefined && diffDistance <= 500) {
         Modal.info(modalItem as ModalFuncProps);
         setDidCloseModal(true);
       }


### PR DESCRIPTION
### 작업 사항
- [x] 사용자, 드라이버 위치 동기화 즉각 안되는 문제 해결
- [x] 100m 이내 드라이버 접근 시 팝업하는 로직 수정


### 요약
- 100m 접근 시 드라이버가 곧 도착한다는 팝업이 띄워지는데 -> 500m로 변경했습니다.
- direction API 문제로 위치 동기화가 바로바로 안되는 문제 해결했습니다.


### 첨부
작업한 사진을 첨부할 경우 여기에 추가하세요.

### 이슈
#258 