### PR TITLE
[JE] 차량 정보 모달 수정

### DIFF
--- a/client/src/routes/User/SearchDriver/SearchDriver.tsx
+++ b/client/src/routes/User/SearchDriver/SearchDriver.tsx
@@ -14,6 +14,7 @@ import { useCustomQuery, useCustomMutation } from '@hooks/useApollo';
 import { addCarInfo } from '@reducers/order';
 import { Message } from '@utils/client-message';
 import { ArgsProps } from 'antd/lib/notification';
+import { carTypeMapperToKor } from '@utils/carTypeMapperToKor';
 
 const StyledSearchDriver = styled.div`
   height: 100%;
@@ -97,8 +98,8 @@ const SearchDriver: FC = () => {
       message: Message.DriverMatchingCompolete,
       description: (
         <>
-          <div>{`${Message.CarType} : ${carInfoData.carNumber}`}</div>
-          <div>{`${Message.CarNumber} : ${carInfoData.carType}`}</div>
+          <div>{`${Message.CarType} : ${carTypeMapperToKor(carInfoData.carType)}`}</div>
+          <div>{`${Message.CarNumber} : ${carInfoData.carNumber}`}</div>
         </>
       ),
     };

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -20,7 +20,6 @@ import {
 import { OrderCallStatus } from '@/types/orderCallStatus';
 import { useCustomQuery } from '@hooks/useApollo';
 import useChatNotifycation from '@hooks/useChatNotifycation';
-import { calcLocationDistance } from '@utils/calcLocationDistance';
 import { InitialState } from '@reducers/.';
 import { ModalFuncProps } from 'antd/lib/modal/Modal';
 import { Message } from '@/utils/client-message';

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -50,8 +50,8 @@ const WaitingDriver = () => {
       title: Message.DriverAjacent,
       content: (
         <>
-          <div>{`${Message.CarType} : ${carInfo.carNumber}`}</div>
-          <div>{`${Message.CarNumber} : ${carInfo.carType}`}</div>
+          <div>{`${Message.CarType} : ${carInfo.carType}`}</div>
+          <div>{`${Message.CarNumber} : ${carInfo.carNumber}`}</div>
         </>
       ),
       centered: true,

--- a/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
+++ b/client/src/routes/User/WaitingDriver/WaitingDriver.tsx
@@ -24,6 +24,7 @@ import { calcLocationDistance } from '@utils/calcLocationDistance';
 import { InitialState } from '@reducers/.';
 import { ModalFuncProps } from 'antd/lib/modal/Modal';
 import { Message } from '@/utils/client-message';
+import { carTypeMapperToKor } from '@/utils/carTypeMapperToKor';
 
 const StyledRow = styled(Row)`
   height: 100%;
@@ -50,7 +51,7 @@ const WaitingDriver = () => {
       title: Message.DriverAjacent,
       content: (
         <>
-          <div>{`${Message.CarType} : ${carInfo.carType}`}</div>
+          <div>{`${Message.CarType} : ${carTypeMapperToKor(carInfo.carType)}`}</div>
           <div>{`${Message.CarNumber} : ${carInfo.carNumber}`}</div>
         </>
       ),

--- a/client/src/utils/carTypeMapperToKor.ts
+++ b/client/src/utils/carTypeMapperToKor.ts
@@ -1,0 +1,15 @@
+const carTypes: string[] = ['large', 'middle', 'small'];
+export type CarTypeEng = typeof carTypes[0] | typeof carTypes[1] | typeof carTypes[2];
+
+export const carTypeMapperToKor = (carType: CarTypeEng): CarTypeEng | '' => {
+  switch (carType) {
+    case carTypes[0]:
+      return '대형';
+    case carTypes[1]:
+      return '중형';
+    case carTypes[2]:
+      return '소형';
+    default:
+      return '';
+  }
+};


### PR DESCRIPTION
### 작업 사항
- [x] 차량 정보 타이틀과 내용의 순서가 바뀜
- [x] mapper를 이용해서 영어로 된 차량 종류 한국어로 띄움 

### 요약
차량타입과 차량번호 정보가 뒤바뀌어 있어서 수정했습니다. 데이터베이스에 영어로 저장되어 있는 차량타입을 한글로 바꾸어서 보여주도록 수정했습니다.


### 첨부
![image](https://user-images.githubusercontent.com/43084680/102243828-f1ab7500-3f3e-11eb-8e9b-176bcad97273.png)

